### PR TITLE
Fix form layout in input form in Workflow Builder

### DIFF
--- a/packages/frinx-workflow-builder/src/components/task-form/graphql-input-form.tsx
+++ b/packages/frinx-workflow-builder/src/components/task-form/graphql-input-form.tsx
@@ -64,7 +64,7 @@ const GraphQLInputsForm: FC<Props> = ({ params, onChange }) => {
         />
       </FormControl>
       <FormControl id="timeout" my={6}>
-        <Box w={1 / 2}>
+        <Box w="50%">
           <FormLabel>Timeout</FormLabel>
           <Input
             variant="filled"


### PR DESCRIPTION
Use percentage instead of fraction on input form width
Control other forms if they have correct width definition