### PR TITLE
use pipe instead of access object property to prefix query expression

### DIFF
--- a/packages/frinx-workflow-builder/src/components/task-form/input-params-forms.tsx
+++ b/packages/frinx-workflow-builder/src/components/task-form/input-params-forms.tsx
@@ -17,7 +17,6 @@ export function renderInputParamForm(
   task: ExtendedTask,
   setState: (p: InputParameters) => void,
   tasks: ExtendedTask[],
-  setIsValid: (isValid: boolean) => void,
 ): ReactNode | null {
   if ('inputParameters' in task) {
     if (task.type === 'DECISION') {
@@ -33,15 +32,7 @@ export function renderInputParamForm(
       return <KafkaInputsForm params={task.inputParameters} onChange={setState} tasks={tasks} task={task} />;
     }
     if (task.type === 'JSON_JQ_TRANSFORM') {
-      return (
-        <JsonInputsForm
-          params={task.inputParameters}
-          onChange={setState}
-          onValidation={setIsValid}
-          tasks={tasks}
-          task={task}
-        />
-      );
+      return <JsonInputsForm params={task.inputParameters} onChange={setState} tasks={tasks} task={task} />;
     }
     if (task.type === 'SIMPLE') {
       if (isGraphQLTaskInputParams(task.inputParameters)) {

--- a/packages/frinx-workflow-builder/src/components/task-form/json-input-form.tsx
+++ b/packages/frinx-workflow-builder/src/components/task-form/json-input-form.tsx
@@ -8,7 +8,6 @@ type Props = {
   tasks: ExtendedTask[];
   task: ExtendedTask;
   onChange: (p: JsonJQInputParams) => void;
-  onValidation: (isValid: boolean) => void;
 };
 
 const JsonJQInputsForm: FC<Props> = ({ params, onChange, tasks, task }) => {
@@ -19,12 +18,12 @@ const JsonJQInputsForm: FC<Props> = ({ params, onChange, tasks, task }) => {
         <Input
           type="text"
           name="queryExpression"
-          value={params.queryExpression.replace(/^\.key/, '')}
+          value={params.queryExpression.replace(/^\.key( \| )?/, '')}
           onChange={(event) => {
             event.persist();
             onChange({
               ...params,
-              queryExpression: `.key${event.target.value}`,
+              queryExpression: `.key | ${event.target.value}`,
             });
           }}
         />

--- a/packages/frinx-workflow-builder/src/components/task-form/task-form.tsx
+++ b/packages/frinx-workflow-builder/src/components/task-form/task-form.tsx
@@ -33,7 +33,6 @@ type Props = {
 
 const TaskForm: FC<Props> = ({ task, tasks, onClose, onFormSubmit }) => {
   const [taskState, setTaskState] = useState(task);
-  const [isValid, setIsValid] = useState(true);
 
   useEffect(() => {
     setTaskState(task);
@@ -53,10 +52,6 @@ const TaskForm: FC<Props> = ({ task, tasks, onClose, onFormSubmit }) => {
         }
       });
     });
-  };
-
-  const handleValidation = (isValidInputParams: boolean) => {
-    setIsValid(isValidInputParams);
   };
 
   return (
@@ -200,13 +195,13 @@ const TaskForm: FC<Props> = ({ task, tasks, onClose, onFormSubmit }) => {
             )}
           </TabPanel>
           {'inputParameters' in taskState && (
-            <TabPanel>{renderInputParamForm(taskState, handleUpdateInputParameters, tasks, handleValidation)}</TabPanel>
+            <TabPanel>{renderInputParamForm(taskState, handleUpdateInputParameters, tasks)}</TabPanel>
           )}
         </TabPanels>
       </Tabs>
       <Divider my={4} />
       <Stack direction="row" spacing={2} align="center">
-        <Button type="submit" colorScheme="blue" isDisabled={!isValid}>
+        <Button type="submit" colorScheme="blue">
           Save changes
         </Button>
         <Button onClick={onClose}>Cancel</Button>

--- a/packages/frinx-workflow-builder/src/helpers/task.helpers.ts
+++ b/packages/frinx-workflow-builder/src/helpers/task.helpers.ts
@@ -124,7 +124,7 @@ function createJsonJQTask(label: TaskLabel): ExtendedJsonJQTask {
     taskReferenceName: `jsonJQ_${getRandomString(4)}`,
     inputParameters: {
       key: '${workflow.output.result}',
-      queryExpression: '.key',
+      queryExpression: '.key | ',
     },
     ...DEFAULT_TASK_OPTIONS,
   };


### PR DESCRIPTION
query expression was prefixed with `.key.` - it works fine with plain object, but not with arrays

it was changed to pipe `.key | `, so it will be more generic - should work for both object and array