### PR TITLE
set prefix to true in minisearch

### DIFF
--- a/packages/frinx-workflow-builder/src/components/left-menu/task-list.tsx
+++ b/packages/frinx-workflow-builder/src/components/left-menu/task-list.tsx
@@ -33,7 +33,10 @@ const TaskList: VoidFunctionComponent<Props> = ({ onTaskAdd, taskDefinitions }) 
     minisearch.addAll(taskDefinitions);
   }, [taskDefinitions, minisearch]);
 
-  const searchFn = throttle(() => getFilteredResults(minisearch.search(searchTerm), taskDefinitions), 60);
+  const searchFn = throttle(
+    () => getFilteredResults(minisearch.search(searchTerm, { prefix: true }), taskDefinitions),
+    60,
+  );
 
   const result = searchTerm.length > 2 ? searchFn() : taskDefinitions;
 

--- a/packages/frinx-workflow-builder/src/components/left-menu/workflow-list.tsx
+++ b/packages/frinx-workflow-builder/src/components/left-menu/workflow-list.tsx
@@ -33,7 +33,7 @@ const WorkflowList: VoidFunctionComponent<Props> = ({ onTaskAdd, workflows }) =>
     minisearch.addAll(workflows);
   }, [workflows, minisearch]);
 
-  const searchFn = throttle(() => getFilteredResults(minisearch.search(searchTerm), workflows), 60);
+  const searchFn = throttle(() => getFilteredResults(minisearch.search(searchTerm, { prefix: true }), workflows), 60);
   const result = searchTerm.length > 2 ? searchFn() : workflows;
 
   return (


### PR DESCRIPTION
Fix searching of tasks & workflows in workflow builder 
Now user is able to search also just with prefix of the keyword