### PR TITLE
more verbose notification on worfklow save

### DIFF
--- a/packages/frinx-workflow-builder/src/app.tsx
+++ b/packages/frinx-workflow-builder/src/app.tsx
@@ -207,19 +207,34 @@ const App: VoidFunctionComponent<Props> = ({
                   }}
                   onSaveWorkflowBtnClick={() => {
                     try {
-                      const newTasks = convertToTasks(elements);
                       const { tasks, ...rest } = workflow;
+                      const newTasks = convertToTasks(elements);
+
                       const { putWorkflow } = callbackUtils.getCallbacks;
                       putWorkflow([
                         {
                           ...rest,
                           tasks: newTasks,
                         },
-                      ]);
+                      ])
+                        .then(() => {
+                          addToastNotification({
+                            title: 'Workflow Saved',
+                            content: 'Workflow was successfully saved',
+                            type: 'success',
+                          });
+                        })
+                        .catch((e) => {
+                          addToastNotification({
+                            title: 'Saving wofklow error',
+                            content: `Workflow could not be saved: ${e}`,
+                            type: 'error',
+                          });
+                        });
                     } catch (e) {
                       addToastNotification({
-                        title: 'Saving workflow error',
-                        content: 'Workflow could not be saved/wrong definition',
+                        title: 'Conversion workflow error',
+                        content: 'Workflow could not be converted/wrong definition',
                         type: 'error',
                       });
                     }


### PR DESCRIPTION
there are now three types of notification in wf builder on save:

1. success notification - when workflow is saved
2. error notification - when conversion failed (leave only start and end node, but do not connect them)
3. error notification - when request to uniflow failed (leave only start and end node and connect it with edge)