### PR TITLE
label-options-box-edit

### DIFF
--- a/packages/frinx-workflow-ui/src/common/wf-autocomplete.tsx
+++ b/packages/frinx-workflow-ui/src/common/wf-autocomplete.tsx
@@ -71,7 +71,6 @@ const WfAutoComplete = forwardRef(({ onChange, options, placeholder, selected = 
             onChange([...selected, results[active].value]);
             setQuery('');
           }
-          setOptionsVisible(false);
           break;
         }
         default:
@@ -154,7 +153,6 @@ const WfAutoComplete = forwardRef(({ onChange, options, placeholder, selected = 
                     onChange([...selected, item.value]);
                     setQuery('');
                   }
-                  setOptionsVisible(false);
                 }}
                 cursor="pointer"
               >


### PR DESCRIPTION
label options box wont close after selecting a label, user needs to click outside of the options box to close it