### PR TITLE
parsing mount params sent when editing and creating device

### DIFF
--- a/packages/frinx-inventory-client/src/pages/create-device/create-device-form.tsx
+++ b/packages/frinx-inventory-client/src/pages/create-device/create-device-form.tsx
@@ -146,7 +146,12 @@ const CreateDeviceForm: VoidFunctionComponent<Props> = ({
     validateOnChange: false,
     validateOnBlur: false,
     onSubmit: (data) => {
-      const updatedData = { ...data, labelIds: selectedLabels.map((label) => label.value), port: Number(data.port) };
+      const updatedData = {
+        ...data,
+        labelIds: selectedLabels.map((label) => label.value),
+        port: Number(data.port),
+        mountParameters: JSON.parse(data.mountParameters),
+      };
       const { blueprintParams, ...rest } = updatedData;
       onFormSubmit(rest);
     },

--- a/packages/frinx-inventory-client/src/pages/edit-device/edit-device-form.tsx
+++ b/packages/frinx-inventory-client/src/pages/edit-device/edit-device-form.tsx
@@ -89,7 +89,11 @@ const EditDeviceForm: FC<Props> = ({ labels, device, onUpdate, onLabelCreate, on
       initialValues: INITIAL_VALUES,
       validationSchema: EditDeviceFormSchema,
       onSubmit: (data) => {
-        const updatedData = { ...data, labelIds: selectedLabels.map((label) => label.value) };
+        const updatedData = {
+          ...data,
+          labelIds: selectedLabels.map((label) => label.value),
+          mountParameters: JSON.parse(data.mountParameters),
+        };
         onUpdate(updatedData);
         setSubmitting(false);
       },


### PR DESCRIPTION
We need to parse mountParameters before sending request to the server because it is duplicitly stringified, so when we are expecting to have JSON in database, all mountParams are strings and not JSON