### PR TITLE
add env for inventory ws protocol

### DIFF
--- a/packages/frinx-dashboard/global.d.ts
+++ b/packages/frinx-dashboard/global.d.ts
@@ -22,6 +22,7 @@ declare interface Window {
     isDeviceTopologyEnabled: boolean;
     URLBasename: string;
     inventoryApiURL: string;
+    inventoryWsURL: string;
     uniresourceApiURL: string;
     uniflowApiDocsURL: string;
     MSALAuthority: string;

--- a/packages/frinx-dashboard/src/inventory-app.tsx
+++ b/packages/frinx-dashboard/src/inventory-app.tsx
@@ -4,7 +4,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { authContext } from './auth-helpers';
 
 type InventoryComponents = Omit<typeof import('@frinx/inventory-client/src'), 'getInventoryApiProvider'> & {
-  InventoryAPIProvider: FC<{ client: InventoryApiClient }>;
+  InventoryAPIProvider: FC<{ client: InventoryApiClient, wsUrl: string }>;
 };
 const InventoryApp: FC = () => {
   const [components, setComponents] = useState<InventoryComponents | null>(null);
@@ -27,7 +27,7 @@ const InventoryApp: FC = () => {
   const { InventoryAPIProvider, InventoryApp: App } = components;
 
   return (
-    <InventoryAPIProvider client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}>
+    <InventoryAPIProvider wsUrl={window.__CONFIG__.inventoryWsURL} client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}>
       <App />
     </InventoryAPIProvider>
   );

--- a/packages/frinx-dashboard/src/inventory-app.tsx
+++ b/packages/frinx-dashboard/src/inventory-app.tsx
@@ -4,7 +4,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { authContext } from './auth-helpers';
 
 type InventoryComponents = Omit<typeof import('@frinx/inventory-client/src'), 'getInventoryApiProvider'> & {
-  InventoryAPIProvider: FC<{ client: InventoryApiClient, wsUrl: string }>;
+  InventoryAPIProvider: FC<{ client: InventoryApiClient; wsUrl: string }>;
 };
 const InventoryApp: FC = () => {
   const [components, setComponents] = useState<InventoryComponents | null>(null);
@@ -27,7 +27,10 @@ const InventoryApp: FC = () => {
   const { InventoryAPIProvider, InventoryApp: App } = components;
 
   return (
-    <InventoryAPIProvider wsUrl={window.__CONFIG__.inventoryWsURL} client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}>
+    <InventoryAPIProvider
+      wsUrl={window.__CONFIG__.inventoryWsURL}
+      client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}
+    >
       <App />
     </InventoryAPIProvider>
   );

--- a/packages/frinx-frontend-server/src/config.ts
+++ b/packages/frinx-frontend-server/src/config.ts
@@ -53,6 +53,7 @@ const config = {
   isUniflowEnabled: stringToBoolean(envString('WORKFLOW_MANAGER_ENABLED')),
   URLBasename: envString('URL_BASENAME'),
   inventoryApiURL: envString('INVENTORY_API_URL'),
+  inventoryWsURL: envString('INVENTORY_WS_URL'),
   unistoreApiURL: envString('UNISTORE_API_URL'),
   uniresourceApiURL: envString('RESOURCE_MANAGER_API_URL'),
   isInventoryEnabled: stringToBoolean(envString('INVENTORY_ENABLED')),

--- a/packages/frinx-inventory-client/src/inventory-api-provider.tsx
+++ b/packages/frinx-inventory-client/src/inventory-api-provider.tsx
@@ -14,10 +14,12 @@ export type InventoryApiClient = {
 
 export type Props = {
   client: InventoryApiClient;
+  wsUrl: string;
 };
 
-const InventoryAPIProvider: FC<Props> = ({ children, client }) => {
-  const wsClient = createWSClient({ url: 'wss://localhost:8001/graphql' });
+const InventoryAPIProvider: FC<Props> = ({ children, client, wsUrl }) => {
+  console.log('InventoryAPIProvider', client, wsUrl)
+  const wsClient = createWSClient({ url: wsUrl });
   const { current: urqlClient } = useRef(
     createClient({
       ...client.clientOptions,

--- a/packages/frinx-inventory-client/src/inventory-api-provider.tsx
+++ b/packages/frinx-inventory-client/src/inventory-api-provider.tsx
@@ -18,7 +18,6 @@ export type Props = {
 };
 
 const InventoryAPIProvider: FC<Props> = ({ children, client, wsUrl }) => {
-  console.log('InventoryAPIProvider', client, wsUrl)
   const wsClient = createWSClient({ url: wsUrl });
   const { current: urqlClient } = useRef(
     createClient({


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             |  hotfix
| Tests Added + Pass?      | No Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->
DevOps team needs to be able to configure the uniconfig shell connections... Currently we use hardcoded value in inventory api provider. The solution is to add env variable add to the window.__CONFIG__ object where are other variables defined.

You can test it when you use .12 VM, and use proxu for UC. connection from UI to the websocket server shouldn't be changed , cause any problem with connections or any change in behavior