### PR TITLE
Fix create resource type

### DIFF
--- a/packages/frinx-resource-manager/src/__generated__/graphql.ts
+++ b/packages/frinx-resource-manager/src/__generated__/graphql.ts
@@ -734,7 +734,7 @@ export type GetPoolDetailQueryVariables = Exact<{
 }>;
 
 
-export type GetPoolDetailQuery = { __typename?: 'Query', QueryResourcePool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Resources: Array<{ __typename?: 'Resource', Description: string | null, Properties: any, id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, ParentResource: { __typename?: 'Resource', ParentPool: { __typename?: 'ResourcePool', id: string, Name: string } } | null, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, ResourceType: { __typename?: 'ResourceType', id: string, Name: string } } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } | null }>, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string } } };
+export type GetPoolDetailQuery = { __typename?: 'Query', QueryResourcePool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Resources: Array<{ __typename?: 'Resource', Description: string | null, Properties: any, id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, ParentResource: { __typename?: 'Resource', ParentPool: { __typename?: 'ResourcePool', id: string, Name: string } } | null, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, ResourceType: { __typename?: 'ResourceType', id: string, Name: string } } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } | null }>, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string } } };
 
 export type AllocatedResourcesQueryVariables = Exact<{
   input: Scalars['Map'];
@@ -792,7 +792,7 @@ export type GetNestedPoolsDetailQueryVariables = Exact<{
 }>;
 
 
-export type GetNestedPoolsDetailQuery = { __typename?: 'Query', QueryResourcePool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } };
+export type GetNestedPoolsDetailQuery = { __typename?: 'Query', QueryResourcePool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } };
 
 export type CreateSetPoolMutationVariables = Exact<{
   input: CreateSetPoolInput;
@@ -893,7 +893,12 @@ export type DeleteResourcePoolMutation = { __typename?: 'Mutation', DeleteResour
 export type GetAllIpPoolsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllIpPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null }> };
+export type GetAllIpPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null }> };
+
+export type GetResourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetResourceTypesQuery = { __typename?: 'Query', QueryResourceTypes: Array<{ __typename?: 'ResourceType', id: string, Name: string }> };
 
 export type GetPoolsQueryVariables = Exact<{
   resourceTypeId?: InputMaybe<Scalars['ID']>;
@@ -901,11 +906,6 @@ export type GetPoolsQueryVariables = Exact<{
 
 
 export type GetPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null }> };
-
-export type GetResourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetResourceTypesQuery = { __typename?: 'Query', QueryResourceTypes: Array<{ __typename?: 'ResourceType', id: string, Name: string }> };
 
 export type ResourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/packages/frinx-resource-manager/src/__generated__/graphql.ts
+++ b/packages/frinx-resource-manager/src/__generated__/graphql.ts
@@ -900,7 +900,7 @@ export type GetPoolsQueryVariables = Exact<{
 }>;
 
 
-export type GetPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null }> };
+export type GetPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null }> };
 
 export type GetResourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -911,13 +911,6 @@ export type ResourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type ResourceTypesQuery = { __typename?: 'Query', QueryResourceTypes: Array<{ __typename?: 'ResourceType', id: string, Name: string }> };
-
-export type CreateResourceTypeMutationVariables = Exact<{
-  input: CreateResourceTypeInput;
-}>;
-
-
-export type CreateResourceTypeMutation = { __typename?: 'Mutation', CreateResourceType: { __typename?: 'CreateResourceTypePayload', resourceType: { __typename?: 'ResourceType', Name: string } } };
 
 export type DeleteResourceTypeMutationVariables = Exact<{
   input: DeleteResourceTypeInput;

--- a/packages/frinx-resource-manager/src/components/expected-properties-form.tsx
+++ b/packages/frinx-resource-manager/src/components/expected-properties-form.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   FormControl,
   FormErrorMessage,
@@ -9,6 +10,7 @@ import {
   Kbd,
   Spacer,
   Text,
+  Tooltip,
 } from '@chakra-ui/react';
 import React, { VoidFunctionComponent } from 'react';
 import FeatherIcon from 'feather-icons-react';
@@ -24,6 +26,7 @@ type Props = {
   label?: string;
   expectedPropertyTypes?: ExpectedProperty[];
   formErrors: ExpectedPropertyErrors;
+  tooltipLabel?: string;
   onPropertyChange: (values: ExpectedProperty[]) => void;
   onPropertyAdd: (values: ExpectedProperty[]) => void;
   onPropertyDelete: (values: ExpectedProperty[]) => void;
@@ -64,6 +67,7 @@ function getExpectedFieldError(
 const ExpectedProperties: VoidFunctionComponent<Props> = ({
   expectedPropertyTypes = [],
   formErrors,
+  tooltipLabel,
   onPropertyAdd,
   onPropertyDelete,
   onPropertyChange,
@@ -95,6 +99,13 @@ const ExpectedProperties: VoidFunctionComponent<Props> = ({
     <>
       <HStack my={3} align="flex-start">
         <Text fontWeight="semibold">{label}</Text>
+        {tooltipLabel != null && (
+          <Tooltip label={tooltipLabel} aria-label="A tooltip">
+            <Box>
+              <FeatherIcon icon="info" size={15} />
+            </Box>
+          </Tooltip>
+        )}
         <Spacer />
         <Button data-cy="add-expected-property" size="sm" onClick={handleOnPoolPropertyAdd}>
           Add new expected property

--- a/packages/frinx-resource-manager/src/hooks/use-resource-pool-actions.ts
+++ b/packages/frinx-resource-manager/src/hooks/use-resource-pool-actions.ts
@@ -92,6 +92,7 @@ const POOL_DETAIL_QUERY = gql`
             id
             Name
             Lang
+            Script
           }
           ResourceType {
             id

--- a/packages/frinx-resource-manager/src/nested-pools-detail-page/nested-pools-detail-page.tsx
+++ b/packages/frinx-resource-manager/src/nested-pools-detail-page/nested-pools-detail-page.tsx
@@ -27,6 +27,7 @@ const POOL_DETAIL_QUERY = gql`
         id
         Name
         Lang
+        Script
       }
       ResourceType {
         id
@@ -47,6 +48,7 @@ const POOL_DETAIL_QUERY = gql`
             id
             Name
             Lang
+            Script
           }
           ResourceType {
             id

--- a/packages/frinx-resource-manager/src/pages/create-pool-page/create-pool-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-pool-page/create-pool-form.tsx
@@ -309,7 +309,10 @@ const CreatePoolForm: VoidFunctionComponent<Props> = ({
               isLoadingPoolProperties={isLoadingRequiredPoolProperties}
               customPoolProperties={requiredPoolProperties}
               formValues={values}
-              onChange={({ key, value }) => setFieldValue(`poolProperties.${key}`, value)}
+              onChange={({ key, value, type }) => {
+                setFieldValue(`poolProperties.${key}`, value);
+                setFieldValue(`poolPropertyTypes.${key}`, type);
+              }}
               poolPropertyErrors={errors.poolProperties}
             />
           ) : (

--- a/packages/frinx-resource-manager/src/pages/create-pool-page/custom-pool-properties-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-pool-page/custom-pool-properties-form.tsx
@@ -59,7 +59,7 @@ const CustomPoolPropertiesForm: VoidFunctionComponent<Props> = ({
     <HStack mt={2} align="flex-start">
       {customPoolProperties.map(({ Name, Type, ...placeholders }) => {
         return (
-          <FormControl key={Name} id={Name} isInvalid={errors[Name] !== undefined} isRequired>
+          <FormControl key={Name} id={Name} isInvalid={errors[Name] != null} isRequired>
             <FormLabel htmlFor={Name}>{Name}</FormLabel>
             <Input
               data-cy={`create-pool-${Name}`}

--- a/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-form.tsx
@@ -187,6 +187,11 @@ const CreateStrategyForm: VoidFunctionComponent<Props> = ({ onFormSubmit, onForm
       </FormControl>
 
       <ExpectedProperties
+        tooltipLabel={`
+          A resource pool is an entity that allocates and deallocates resources for a single specific resource type.
+          When you are creating a new resource pool, you need to define what properties it will have.
+          So, that we can use them when we will allocate resources for you.
+        `}
         label="Expected pool properties"
         formErrors={{
           duplicatePropertyKey: formErrors.expectedPoolPropertyTypesDuplicatedKeys,
@@ -275,6 +280,11 @@ const CreateStrategyForm: VoidFunctionComponent<Props> = ({ onFormSubmit, onForm
       </FormControl>
 
       <ExpectedProperties
+        tooltipLabel={`
+          Resource type is a blueprint for how to represent a resource instance. 
+          A resource type is essentially a set of property types, where each property type defines as object of
+          "Name" of the property and "Type" such as int, string, float etc.
+        `}
         label="Expected resource type structure"
         formErrors={{
           duplicatePropertyKey: formErrors.resourceTypePropertiesDuplicatedKeys,

--- a/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-form.tsx
@@ -133,7 +133,7 @@ const CreateStrategyForm: VoidFunctionComponent<Props> = ({ onFormSubmit, onForm
     onSubmit: (data) => {
       const updatedData = {
         ...data,
-        script: data.capacityScript.concat(data.invokeScript),
+        script: data.capacityScript.concat('\n\n'.concat(data.invokeScript)),
       };
 
       onFormSubmit({

--- a/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-form.tsx
@@ -1,10 +1,14 @@
 import React, { useEffect, VoidFunctionComponent } from 'react';
-import { Button, Code, FormControl, FormLabel, HStack, Input, Select, Spacer, Tooltip } from '@chakra-ui/react';
-import FeatherIcon from 'feather-icons-react';
+import { Button, FormControl, FormErrorMessage, FormLabel, HStack, Input, Select, Spacer } from '@chakra-ui/react';
 import { FormikErrors, FormikValues, useFormik } from 'formik';
 import { Editor, unwrap } from '@frinx/shared/src';
 import * as yup from 'yup';
-import { AllocationStrategyLang } from '../../__generated__/graphql';
+import { omit } from 'lodash';
+import {
+  AllocationStrategyLang,
+  CreateAllocationStrategyInput,
+  CreateResourceTypeInput,
+} from '../../__generated__/graphql';
 import 'ace-builds/webpack-resolver';
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/mode-python';
@@ -12,40 +16,43 @@ import 'ace-builds/src-noconflict/theme-tomorrow';
 import 'ace-builds/src-noconflict/ext-language_tools';
 import ExpectedProperties, { ExpectedProperty } from '../../components/expected-properties-form';
 
-function getDefaultScriptValue(lang: 'js' | 'py'): string {
+function getDefaultInvokeScript(lang: 'js' | 'py'): string {
+  if (lang === 'js') {
+    return `function invoke() {
+    log(JSON.stringify({ respool: resourcePool.ResourcePoolName, currentRes: currentResources }));
+    return { vlan: userInput.desiredVlan };
+}`;
+  } else {
+    return `def invoke():
+  log(JSON.stringify({ 'respool': resourcePool.ResourcePoolName, 'currentRes': currentResources }))
+  return { 'vlan': userInput.desiredVlan }`;
+  }
+}
+
+function getDefaultCapacityScript(lang: 'js' | 'py'): string {
   if (lang === 'js') {
     return `function capacity() {
-  // here will be your code, that will calculate capacity of the resource pool
-
-  // this function needs to return free and utilized capacity of the resource pool
-  // e.g. next example returns 0 for both free and utilized capacity
-  return { free: 0, utilized: 0 };
-}
-
-function invoke() {
-  log(JSON.stringify({ respool: resourcePool.ResourcePoolName, currentRes: currentResources }));
-  return { vlan: userInput.desiredVlan };
-}
-    `;
+      // here will be your code, that will calculate capacity of the resource pool
+    
+      // this function needs to return free and utilized capacity of the resource pool
+      // e.g. next example returns 0 for both free and utilized capacity
+      return { free: 0, utilized: 0 };
+}`;
   } else {
     return `def capacity():
-  # here will be your code
-
-  # this function needs to return free and utilized capacity of the resource pool
-  # e.g. next example returns 0 for both free and utilized capacity
-  return { 'free': 0, 'utilized': 0 }
-
-def invoke():
-  log(JSON.stringify({ 'respool': resourcePool.ResourcePoolName, 'currentRes': currentResources }))
-  return { 'vlan': userInput.desiredVlan }
-    `;
+    # here will be your code, that will calculate capacity of the resource pool
+    
+    # this function needs to return free and utilized capacity of the resource pool
+    # e.g. next example returns 0 for both free and utilized capacity
+    return { 'free': 0, 'utilized': 0 }`;
   }
 }
 
 const INITIAL_VALUES: FormValues = {
   name: '',
   lang: 'js',
-  script: getDefaultScriptValue('js'),
+  capacityScript: getDefaultCapacityScript('js'),
+  invokeScript: getDefaultInvokeScript('js'),
   expectedPoolPropertyTypes: [{ key: 'address', type: 'string' }],
   resourceTypeProperties: [{ key: 'address', type: 'string' }],
 };
@@ -69,7 +76,8 @@ yup.addMethod(yup.array, 'unique', function unique(message, mapper = (a: unknown
 const validationSchema = yup.object().shape({
   name: yup.string().required('Name of allocation strategy is required'),
   lang: yup.string().required('Language of script for allocation strategy is required'),
-  script: yup.string().required('Allocation strategy script is required'),
+  capacityScript: yup.string().required('Capacity script is required'),
+  invokeScript: yup.string().required('Invoke script is required'),
   expectedPoolPropertyTypes: yup
     .array()
     .of(
@@ -93,12 +101,16 @@ const validationSchema = yup.object().shape({
 export type FormValues = {
   name: string;
   lang: AllocationStrategyLang;
-  script: string;
+  capacityScript: string;
+  invokeScript: string;
   expectedPoolPropertyTypes?: ExpectedProperty[];
   resourceTypeProperties?: ExpectedProperty[];
 };
 type Props = {
-  onFormSubmit: (values: FormValues) => void;
+  onFormSubmit: (values: {
+    stratInput: CreateAllocationStrategyInput;
+    resourceTypeInput: CreateResourceTypeInput;
+  }) => void;
   onFormCancel: () => void;
 };
 
@@ -119,18 +131,42 @@ const CreateStrategyForm: VoidFunctionComponent<Props> = ({ onFormSubmit, onForm
     validateOnChange: false,
     validationSchema,
     onSubmit: (data) => {
-      onFormSubmit(data);
+      const updatedData = {
+        ...data,
+        script: data.capacityScript.concat(data.invokeScript),
+      };
+
+      onFormSubmit({
+        stratInput: {
+          ...omit(updatedData, ['capacityScript', 'invokeScript', 'resourceTypeProperties']),
+          expectedPoolPropertyTypes: updatedData.expectedPoolPropertyTypes?.reduce(
+            (acc, curr) => ({ ...acc, [curr.key]: curr.type }),
+            {},
+          ),
+        },
+        resourceTypeInput: {
+          resourceName: updatedData.name,
+          resourceProperties: updatedData.resourceTypeProperties?.reduce(
+            (acc, curr) => ({ ...acc, [curr.key]: curr.type }),
+            {},
+          ),
+        },
+      });
       setSubmitting(false);
     },
   });
 
   useEffect(() => {
-    if (!touched.script) {
-      setFieldValue('script', getDefaultScriptValue(values.lang));
+    if (!touched.invokeScript) {
+      setFieldValue('invokeScript', getDefaultInvokeScript(values.lang));
+    }
+
+    if (!touched.capacityScript) {
+      setFieldValue('capacityScript', getDefaultCapacityScript(values.lang));
     }
     // because we do not want to execute this effect when script's touched state changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values.lang, setFieldValue, getDefaultScriptValue]);
+  }, [values.lang, setFieldValue, getDefaultInvokeScript, getDefaultCapacityScript]);
 
   type FormErrors = typeof errors &
     FormikErrors<{ expectedPoolPropertyTypesDuplicatedKeys?: string; resourceTypePropertiesDuplicatedKeys?: string }>;
@@ -178,29 +214,24 @@ const CreateStrategyForm: VoidFunctionComponent<Props> = ({ onFormSubmit, onForm
         </Select>
       </FormControl>
 
-      <FormControl marginY={5}>
-        <FormLabel data-cy="new-strategy-editor">Invoke function that will allocate resources</FormLabel>
-        <HStack>
-          <Code colorScheme="blue">{values.lang === 'js' ? 'function invoke() {' : 'def invoke():'}</Code>
-          <Tooltip label="In the editor below you can write your own allocation strategy script.">
-            <FeatherIcon size={20} icon="info" />
-          </Tooltip>
-        </HStack>
+      <FormControl marginY={5} isRequired isInvalid={errors.capacityScript != null}>
+        <FormLabel data-cy="new-strategy-editor">
+          Capacity function that will calculate the capacity of resource pool
+        </FormLabel>
         <Editor
-          name="script"
-          height="450px"
+          height="200px"
           width="100%"
           mode={values.lang === 'js' ? 'javascript' : 'python'}
           theme="tomorrow"
           editorProps={{ $blockScrolling: true }}
-          value={values.script}
+          value={values.capacityScript}
           fontSize={16}
           onChange={(value) => {
-            setFieldValue('script', value);
-            if (INITIAL_VALUES.script === value) {
-              setFieldTouched('script', false);
+            setFieldValue('capacityScript', value);
+            if (INITIAL_VALUES.capacityScript === value) {
+              setFieldTouched('capacityScript', false);
             } else {
-              setFieldTouched('script', true);
+              setFieldTouched('capacityScript', true);
             }
           }}
           setOptions={{
@@ -211,7 +242,36 @@ const CreateStrategyForm: VoidFunctionComponent<Props> = ({ onFormSubmit, onForm
             tabSize: 2,
           }}
         />
-        <Code colorScheme="blue">{values.lang === 'js' ? '}' : ''}</Code>
+        <FormErrorMessage>{errors.capacityScript}</FormErrorMessage>
+      </FormControl>
+
+      <FormControl marginY={5} isRequired isInvalid={errors.invokeScript != null}>
+        <FormLabel data-cy="new-strategy-editor">Invoke function that will allocate resources</FormLabel>
+        <Editor
+          height="200px"
+          width="100%"
+          mode={values.lang === 'js' ? 'javascript' : 'python'}
+          theme="tomorrow"
+          editorProps={{ $blockScrolling: true }}
+          value={values.invokeScript}
+          fontSize={16}
+          onChange={(value) => {
+            setFieldValue('invokeScript', value);
+            if (INITIAL_VALUES.invokeScript === value) {
+              setFieldTouched('invokeScript', false);
+            } else {
+              setFieldTouched('invokeScript', true);
+            }
+          }}
+          setOptions={{
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: true,
+            enableSnippets: true,
+            showLineNumbers: true,
+            tabSize: 2,
+          }}
+        />
+        <FormErrorMessage>{errors.invokeScript}</FormErrorMessage>
       </FormControl>
 
       <ExpectedProperties

--- a/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-strategy-page/create-strategy-page.tsx
@@ -1,15 +1,16 @@
 import React, { VoidFunctionComponent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation } from 'urql';
-import { omit } from 'lodash';
 import { Heading, Flex, Box } from '@chakra-ui/react';
 import gql from 'graphql-tag';
 import { useNotifications } from '@frinx/shared/src';
 import {
   CreateAllocationStrategyAndResourceTypeMutation,
   CreateAllocationStrategyAndResourceTypeMutationVariables,
+  CreateAllocationStrategyInput,
+  CreateResourceTypeInput,
 } from '../../__generated__/graphql';
-import CreateStrategyForm, { FormValues } from './create-strategy-form';
+import CreateStrategyForm from './create-strategy-form';
 
 const CREATE_STRATEGY_MUTATION = gql`
   mutation CreateAllocationStrategyAndResourceType(
@@ -45,22 +46,16 @@ const CreateStrategyPage: VoidFunctionComponent<Props> = ({ onSaveButtonClick })
     CreateAllocationStrategyAndResourceTypeMutationVariables
   >(CREATE_STRATEGY_MUTATION);
 
-  const handleFormSubmit = (values: FormValues) => {
+  const handleFormSubmit = ({
+    stratInput,
+    resourceTypeInput,
+  }: {
+    stratInput: CreateAllocationStrategyInput;
+    resourceTypeInput: CreateResourceTypeInput;
+  }) => {
     addStrategy({
-      stratInput: {
-        ...omit(values, 'resourceTypeProperties'),
-        expectedPoolPropertyTypes: values.expectedPoolPropertyTypes?.reduce(
-          (acc, curr) => ({ ...acc, [curr.key]: curr.type }),
-          {},
-        ),
-      },
-      resourceTypeInput: {
-        resourceName: values.name,
-        resourceProperties: values.resourceTypeProperties?.reduce(
-          (acc, curr) => ({ ...acc, [curr.key]: curr.type }),
-          {},
-        ),
-      },
+      stratInput,
+      resourceTypeInput,
     })
       .then(({ error }) => {
         if (error != null) {

--- a/packages/frinx-resource-manager/src/pages/ipam-page/ipam-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/ipam-page/ipam-page.tsx
@@ -115,6 +115,7 @@ const IpamPoolPage: VoidFunctionComponent = () => {
 
   const handleOnClearSearch = () => {
     setSearchText('');
+    setSelectedResourceType('');
     clearAllTags();
   };
 
@@ -170,6 +171,7 @@ const IpamPoolPage: VoidFunctionComponent = () => {
           isLoading={isQueryLoading || isMutationLoading}
           onDeleteBtnClick={handleDeleteBtnClick}
           onTagClick={handleOnTagClick}
+          onStrategyClick={handleOnStrategyClick}
         />
       </Box>
     </>

--- a/packages/frinx-resource-manager/src/pages/ipam-page/ipam-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/ipam-page/ipam-page.tsx
@@ -10,6 +10,8 @@ import {
   DeletePoolMutation,
   DeletePoolMutationMutationVariables,
   GetAllIpPoolsQuery,
+  GetResourceTypesQuery,
+  GetResourceTypesQueryVariables,
 } from '../../__generated__/graphql';
 import PoolsTable from '../pools-page/pools-table';
 
@@ -28,6 +30,7 @@ const POOLS_QUERY = gql`
         id
         Name
         Lang
+        Script
       }
       ResourceType {
         id
@@ -55,11 +58,24 @@ const DELETE_POOL_MUTATION = gql`
   }
 `;
 
+const GET_RESOURCE_TYPES = gql`
+  query GetResourceTypes {
+    QueryResourceTypes {
+      id
+      Name
+    }
+  }
+`;
+
 const IpamPoolPage: VoidFunctionComponent = () => {
+  const [selectedResourceType, setSelectedResourceType] = React.useState<string>('');
   const context = useMemo(() => ({ additionalTypenames: ['ResourcePool'] }), []);
   const [{ data, fetching: isQueryLoading, error }] = useQuery<GetAllIpPoolsQuery>({
     query: POOLS_QUERY,
     context,
+  });
+  const [{ data: resourceTypes }] = useQuery<GetResourceTypesQuery, GetResourceTypesQueryVariables>({
+    query: GET_RESOURCE_TYPES,
   });
   const [{ fetching: isMutationLoading }, deletePool] = useMutation<
     DeletePoolMutation,
@@ -88,6 +104,12 @@ const IpamPoolPage: VoidFunctionComponent = () => {
         type: 'error',
         content: 'There was a problem with deletion of the resource pool',
       });
+    }
+  };
+
+  const handleOnStrategyClick = (id?: string) => {
+    if (id != null) {
+      setSelectedResourceType(id);
     }
   };
 
@@ -138,6 +160,10 @@ const IpamPoolPage: VoidFunctionComponent = () => {
           clearAllTags={clearAllTags}
           onTagClick={handleOnTagClick}
           onClearSearch={handleOnClearSearch}
+          canFilterByResourceType
+          resourceTypes={resourceTypes?.QueryResourceTypes}
+          selectedResourceType={selectedResourceType}
+          setSelectedResourceType={handleOnStrategyClick}
         />
         <PoolsTable
           pools={ipPools}

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
@@ -31,6 +31,7 @@ const ALL_POOLS_QUERY = gql`
         id
         Name
         Lang
+        Script
       }
       ResourceType {
         id
@@ -110,6 +111,12 @@ const PoolsPage: VoidFunctionComponent = () => {
     setSelectedResourceType('');
   };
 
+  const handleOnStrategyClick = (id?: string) => {
+    if (id != null) {
+      setSelectedResourceType(id);
+    }
+  };
+
   if (isQueryLoading) {
     return <Progress isIndeterminate size="sm" mt={-10} />;
   }
@@ -180,6 +187,7 @@ const PoolsPage: VoidFunctionComponent = () => {
           isLoading={isQueryLoading || isMutationLoading}
           onDeleteBtnClick={handleDeleteBtnClick}
           onTagClick={handleOnTagClick}
+          onStrategyClick={handleOnStrategyClick}
         />
       </Box>
     </>

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-table.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-table.tsx
@@ -24,6 +24,7 @@ type Props = {
   pools: GetPoolsQuery['QueryRootResourcePools'];
   isLoading: boolean;
   isNestedShown?: boolean;
+  onStrategyClick: (name?: string) => void;
   onDeleteBtnClick: (id: string) => void;
   onTagClick?: (tag: string) => void;
 };
@@ -31,6 +32,7 @@ type Props = {
 const PoolsTable: VoidFunctionComponent<Props> = ({
   pools,
   onDeleteBtnClick,
+  onStrategyClick,
   isLoading,
   isNestedShown = true,
   onTagClick,
@@ -100,7 +102,13 @@ const PoolsTable: VoidFunctionComponent<Props> = ({
                   </Td>
                   <Td>{pool.PoolType}</Td>
                   <Td>
-                    <Text as="span" fontFamily="monospace" color="red">
+                    <Text
+                      as="span"
+                      fontFamily="monospace"
+                      color="red"
+                      cursor="pointer"
+                      onClick={() => onStrategyClick(pool.ResourceType?.id)}
+                    >
                       {pool.ResourceType?.Name}
                     </Text>
                   </Td>

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-table.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-table.tsx
@@ -24,7 +24,7 @@ type Props = {
   pools: GetPoolsQuery['QueryRootResourcePools'];
   isLoading: boolean;
   isNestedShown?: boolean;
-  onStrategyClick: (name?: string) => void;
+  onStrategyClick?: (name?: string) => void;
   onDeleteBtnClick: (id: string) => void;
   onTagClick?: (tag: string) => void;
 };
@@ -107,7 +107,7 @@ const PoolsTable: VoidFunctionComponent<Props> = ({
                       fontFamily="monospace"
                       color="red"
                       cursor="pointer"
-                      onClick={() => onStrategyClick(pool.ResourceType?.id)}
+                      onClick={() => onStrategyClick?.(pool.ResourceType?.id)}
                     >
                       {pool.ResourceType?.Name}
                     </Text>

--- a/packages/frinx-resource-manager/src/pages/resource-types-page/create-resource-type-modal.tsx
+++ b/packages/frinx-resource-manager/src/pages/resource-types-page/create-resource-type-modal.tsx
@@ -18,11 +18,12 @@ import * as yup from 'yup';
 import { FormikErrors, FormikValues, useFormik } from 'formik';
 import { unwrap } from '@frinx/shared/src';
 import ExpectedProperties, { ExpectedProperty } from '../../components/expected-properties-form';
+import { CreateResourceTypeInput } from '../../__generated__/graphql';
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  onCreate: (resourceTypeName: string) => void;
+  onCreate: (resourceType: CreateResourceTypeInput) => void;
 };
 
 type FormValues = {
@@ -70,7 +71,17 @@ const CreateResourceTypeModal: VoidFunctionComponent<Props> = ({ isOpen, onClose
       validateOnChange: false,
       validationSchema,
       onSubmit: (data) => {
-        onCreate(data.resourceTypeName);
+        onCreate({
+          resourceName: data.resourceTypeName,
+          resourceProperties:
+            data.resourceTypeProperties?.reduce(
+              (acc, curr) => ({
+                ...acc,
+                [curr.key]: curr.type,
+              }),
+              {},
+            ) ?? {},
+        });
         onClose();
       },
     },

--- a/packages/frinx-resource-manager/src/pages/resource-types-page/resource-types-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/resource-types-page/resource-types-page.tsx
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import React, { useMemo, VoidFunctionComponent } from 'react';
 import { useMutation, useQuery } from 'urql';
 import {
+  CreateResourceTypeInput,
   CreateResourceTypeMutation,
   CreateResourceTypeMutationVariables,
   DeleteResourceTypeMutation,
@@ -62,12 +63,12 @@ const ResourceTypesPage: VoidFunctionComponent = () => {
     CREATE_RESOURCE_TYPE_MUTATION,
   );
 
-  const handleOnCreate = (resourceTypeName: string) => {
+  const handleOnCreate = ({ resourceName, resourceProperties }: CreateResourceTypeInput) => {
     createResourceType(
       {
         input: {
-          resourceName: resourceTypeName,
-          resourceProperties: {},
+          resourceName,
+          resourceProperties,
         },
       },
       ctx,

--- a/packages/frinx-resource-manager/src/pages/resource-types-page/resource-types-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/resource-types-page/resource-types-page.tsx
@@ -1,17 +1,13 @@
-import { Button, Flex, Heading, Progress, Spacer, Text, useDisclosure } from '@chakra-ui/react';
+import { Flex, Heading, Progress, Text } from '@chakra-ui/react';
 import { useNotifications } from '@frinx/shared/src';
 import gql from 'graphql-tag';
 import React, { useMemo, VoidFunctionComponent } from 'react';
 import { useMutation, useQuery } from 'urql';
 import {
-  CreateResourceTypeInput,
-  CreateResourceTypeMutation,
-  CreateResourceTypeMutationVariables,
   DeleteResourceTypeMutation,
   DeleteResourceTypeMutationVariables,
   ResourceTypesQuery,
 } from '../../__generated__/graphql';
-import CreateResourceTypeModal from './create-resource-type-modal';
 import ResourceTypesTable from './resource-types-table';
 
 const RESOURCE_TYPES_QUERY = gql`
@@ -19,16 +15,6 @@ const RESOURCE_TYPES_QUERY = gql`
     QueryResourceTypes {
       id
       Name
-    }
-  }
-`;
-
-const CREATE_RESOURCE_TYPE_MUTATION = gql`
-  mutation CreateResourceType($input: CreateResourceTypeInput!) {
-    CreateResourceType(input: $input) {
-      resourceType {
-        Name
-      }
     }
   }
 `;
@@ -48,7 +34,6 @@ const ResourceTypesPage: VoidFunctionComponent = () => {
     }),
     [],
   );
-  const { isOpen, onClose, onOpen } = useDisclosure();
   const notification = useNotifications();
 
   const [{ data, fetching, error }] = useQuery<ResourceTypesQuery>({
@@ -59,29 +44,6 @@ const ResourceTypesPage: VoidFunctionComponent = () => {
   const [, deleteResourceType] = useMutation<DeleteResourceTypeMutation, DeleteResourceTypeMutationVariables>(
     DELETE_RESOURCE_TYPE_MUTATION,
   );
-  const [, createResourceType] = useMutation<CreateResourceTypeMutation, CreateResourceTypeMutationVariables>(
-    CREATE_RESOURCE_TYPE_MUTATION,
-  );
-
-  const handleOnCreate = ({ resourceName, resourceProperties }: CreateResourceTypeInput) => {
-    createResourceType(
-      {
-        input: {
-          resourceName,
-          resourceProperties,
-        },
-      },
-      ctx,
-    )
-      .then(({ error: createResourceTypeError }) => {
-        if (createResourceTypeError != null) {
-          throw Error();
-        }
-
-        notification.addToastNotification({ content: 'Resource type created successfully', type: 'success' });
-      })
-      .catch(() => notification.addToastNotification({ content: 'Resource type creation failed', type: 'error' }));
-  };
 
   const handleOnDelete = (resourceTypeId: string) => {
     deleteResourceType({ input: { resourceTypeId } }, ctx)
@@ -105,15 +67,10 @@ const ResourceTypesPage: VoidFunctionComponent = () => {
 
   return (
     <>
-      <CreateResourceTypeModal isOpen={isOpen} onClose={onClose} onCreate={handleOnCreate} />
       <Flex marginBottom={5} alignItems="center">
         <Heading as="h1" size="xl">
           Resource Types
         </Heading>
-        <Spacer />
-        <Button data-cy="create-resource-type" colorScheme="blue" onClick={onOpen}>
-          Create resource type
-        </Button>
       </Flex>
       <ResourceTypesTable resourceTypes={data.QueryResourceTypes} onDelete={handleOnDelete} />
     </>

--- a/packages/frinx-resource-manager/src/pages/strategies-page/strategies-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/strategies-page/strategies-page.tsx
@@ -36,6 +36,7 @@ const DELETE_STRATEGY_MUTATION = gql`
 type ScriptState = {
   lang: string;
   script: string;
+  name?: string;
 };
 
 const StrategiesPage: VoidFunctionComponent = () => {
@@ -81,8 +82,8 @@ const StrategiesPage: VoidFunctionComponent = () => {
     },
     [deleteStrategy, addToastNotification],
   );
-  const handleScriptBtnClick = (lang: string, script: string) => {
-    setScriptState({ lang, script });
+  const handleScriptBtnClick = (lang: string, script: string, name?: string) => {
+    setScriptState({ lang, script, name });
   };
 
   if (fetching) {
@@ -125,6 +126,7 @@ const StrategiesPage: VoidFunctionComponent = () => {
           setScriptState(null);
         }}
         {...scriptState}
+        strategyName={scriptState?.name}
       />
     </>
   );

--- a/packages/frinx-resource-manager/src/pages/strategies-page/strategies-table.tsx
+++ b/packages/frinx-resource-manager/src/pages/strategies-page/strategies-table.tsx
@@ -5,7 +5,7 @@ import { QueryAllocationStrategiesQuery } from '../../__generated__/graphql';
 
 type Props = {
   strategies: QueryAllocationStrategiesQuery['QueryAllocationStrategies'];
-  onScriptBtnClick: (lang: string, script: string) => void;
+  onScriptBtnClick: (lang: string, script: string, name: string) => void;
   onDeleteBtnClick: (id: string) => void;
 };
 
@@ -40,7 +40,7 @@ const StrategiesTable: VoidFunctionComponent<Props> = ({ strategies, onScriptBtn
                   aria-label="code"
                   icon={<Icon size={20} as={FeatherIcon} icon="code" color="blue" />}
                   onClick={() => {
-                    onScriptBtnClick(strategy.Lang, strategy.Script);
+                    onScriptBtnClick(strategy.Lang, strategy.Script, strategy.Name);
                   }}
                 />
                 <IconButton

--- a/packages/frinx-resource-manager/src/pages/strategies-page/strategy-script-modal.tsx
+++ b/packages/frinx-resource-manager/src/pages/strategies-page/strategy-script-modal.tsx
@@ -8,22 +8,30 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Text,
 } from '@chakra-ui/react';
 import { Editor } from '@frinx/shared/src';
 
 type Props = {
   script?: string;
   lang?: string;
+  strategyName?: string;
   isOpen: boolean;
   onClose: () => void;
 };
 
-const StrategyScriptModal: VoidFunctionComponent<Props> = ({ script, lang, isOpen, onClose }) => {
+const StrategyScriptModal: VoidFunctionComponent<Props> = ({ strategyName, script, lang, isOpen, onClose }) => {
   return (
     <Modal size="5xl" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>View Strategy</ModalHeader>
+        <ModalHeader>
+          View{' '}
+          <Text as="span" color="red" fontFamily="monospace">
+            {strategyName}
+          </Text>{' '}
+          Strategy
+        </ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           {script != null && lang != null && (


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-463`
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->
**Things done in this PR**
- fix variables sent in request when creating allocation strategy
- remove button to create resource type (only available when creating allocation strategy in the same form)
- make resource type in pools table clickable so that user can filter by them
- move script of allocation strategy into two separate editors, for the sake of simplicity
- added tooltips where we explain usage of expected pool properties in create strategy form