### PR TITLE
Fd 416 yang ipv6 changes

### DIFF
--- a/packages/frinx-api/src/unistore/types.ts
+++ b/packages/frinx-api/src/unistore/types.ts
@@ -41,7 +41,7 @@ const VpnServicesOutputValidator = t.type({
       'resource-assignment': optional(
         t.type({
           bearer: t.type({
-            'default-c-vlan': t.number,
+            'default-c-vlan': optional(t.number),
           }),
           ipv4: optional(
             t.type({
@@ -85,8 +85,10 @@ export type CreateVpnServiceInput = {
         }[];
       };
       'vpn-service-topology': string;
-      'resource-assignment'?: {
-        bearer: string;
+      'resource-assignment': {
+        bearer: {
+          'default-c-vlan'?: string;
+        };
         ipv4?: {
           'permit-manual-assignment'?: boolean;
           'management-pool-tag'?: string;
@@ -103,8 +105,6 @@ export type CreateVpnServiceInput = {
           'lan-prefix-length'?: number;
         };
       };
-
-      'default-c-vlan': string;
     },
   ];
 };

--- a/packages/frinx-api/src/unistore/types.ts
+++ b/packages/frinx-api/src/unistore/types.ts
@@ -38,7 +38,32 @@ const VpnServicesOutputValidator = t.type({
         }),
       ),
       'vpn-service-topology': t.string,
-      'default-c-vlan': t.number,
+      'resource-assignment': optional(
+        t.type({
+          bearer: t.type({
+            'default-c-vlan': t.number,
+          }),
+          ipv4: optional(
+            t.type({
+              'permit-manual-assignment': optional(t.boolean),
+              'management-pool-tag': optional(t.string),
+              'ip-connection-pool-tag': optional(t.string),
+              'ip-connection-prefix-length': optional(t.number),
+              'lan-pool-tag': optional(t.string),
+              'lan-prefix-length': optional(t.number),
+            }),
+          ),
+          ipv6: optional(
+            t.type({
+              'permit-manual-assignment': optional(t.boolean),
+              'management-pool-tag': optional(t.string),
+              'ip-connection-pool-tag': optional(t.string),
+              'lan-pool-tag': optional(t.string),
+              'lan-prefix-length': optional(t.number),
+            }),
+          ),
+        }),
+      ),
     }),
   ),
 });
@@ -60,6 +85,25 @@ export type CreateVpnServiceInput = {
         }[];
       };
       'vpn-service-topology': string;
+      'resource-assignment'?: {
+        bearer: string;
+        ipv4?: {
+          'permit-manual-assignment'?: boolean;
+          'management-pool-tag'?: string;
+          'ip-connection-pool-tag'?: string;
+          'ip-connection-prefix-length'?: number;
+          'lan-pool-tag'?: string;
+          'lan-prefix-length'?: number;
+        };
+        ipv6?: {
+          'permit-manual-assignment'?: boolean;
+          'management-pool-tag'?: string;
+          'ip-connection-pool-tag'?: string;
+          'lan-pool-tag'?: string;
+          'lan-prefix-length'?: number;
+        };
+      };
+
       'default-c-vlan': string;
     },
   ];
@@ -257,6 +301,18 @@ const IPConnectionValidator = t.type({
       ),
     }),
   ),
+  ipv6: optional(
+    t.type({
+      'address-allocation-type': optional(t.string),
+      addresses: optional(
+        t.type({
+          'customer-address': optional(t.string),
+          'prefix-length': optional(t.number),
+          'provider-address': optional(t.string),
+        }),
+      ),
+    }),
+  ),
 });
 
 export type IPConnectionOutput = t.TypeOf<typeof IPConnectionValidator>;
@@ -396,6 +452,14 @@ export type CreateIPConnectionInput = {
     };
   };
   ipv4?: {
+    'address-allocation-type'?: string;
+    addresses?: {
+      'customer-address'?: string;
+      'prefix-length'?: number;
+      'provider-address'?: string;
+    };
+  };
+  ipv6?: {
     'address-allocation-type'?: string;
     addresses?: {
       'customer-address'?: string;


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-416` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
changes in unistore frinx-api network-types, so it is in sync with ipv6 gamma yang model changes.
to use it with gamma (without making new release):
```
cd packages/frinx-api
yarn build
cp -r dist/esm/dist/ ../../../frinx-gamma/node_modules/@frinx/api
```
 