### PR TITLE
Fix pools table filter

### DIFF
--- a/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
+++ b/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
@@ -36,16 +36,11 @@ const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
           <Select
             data-cy="select-resource-type"
             value={selectedResourceType}
-            onChange={(e) =>
-              setSelectedResourceType &&
-              setSelectedResourceType(e.target.value)
-            }
+            onChange={(e) => setSelectedResourceType && setSelectedResourceType(e.target.value)}
             variant="outline"
             bgColor="white"
           >
-            <option value=''>
-              Select resource type to filter
-            </option>
+            <option value="">Select resource type to filter</option>
             {resourceTypes.map(({ Name, id }) => (
               <option key={id} value={id}>
                 {Name}

--- a/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
+++ b/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
@@ -36,7 +36,10 @@ const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
           <Select
             data-cy="select-resource-type"
             value={selectedResourceType}
-            onChange={(e) => setSelectedResourceType && setSelectedResourceType(e.target.value)}
+            onChange={(e) =>
+              setSelectedResourceType &&
+              setSelectedResourceType(e.target.value === 'Select resource type to filter' ? '' : e.target.value)
+            }
             variant="outline"
             bgColor="white"
           >

--- a/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
+++ b/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
@@ -38,12 +38,12 @@ const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
             value={selectedResourceType}
             onChange={(e) =>
               setSelectedResourceType &&
-              setSelectedResourceType(e.target.value === 'Select resource type to filter' ? '' : e.target.value)
+              setSelectedResourceType(e.target.value)
             }
             variant="outline"
             bgColor="white"
           >
-            <option onChange={() => setSelectedResourceType && setSelectedResourceType('')}>
+            <option value=''>
               Select resource type to filter
             </option>
             {resourceTypes.map(({ Name, id }) => (

--- a/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
+++ b/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
@@ -40,7 +40,7 @@ const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
             variant="outline"
             bgColor="white"
           >
-            <option onClick={() => setSelectedResourceType && setSelectedResourceType('')}>
+            <option onChange={() => setSelectedResourceType && setSelectedResourceType('')}>
               Select resource type to filter
             </option>
             {resourceTypes.map(({ Name, id }) => (

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
@@ -125,7 +125,7 @@ const PoolsPage: VoidFunctionComponent = () => {
     return <div>{error?.message}</div>;
   }
 
-  const isSelectedResourceTypeEmpty = selectedResourceType === null || selectedResourceType.trim().length === 0;
+  const isSelectedResourceTypeEmpty = selectedResourceType == null || selectedResourceType.trim().length === 0;
 
   const resourcePools = results.filter((pool) => {
     if (!isSelectedResourceTypeEmpty && selectedTags.length > 0) {

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
@@ -71,7 +71,7 @@ const GET_RESOURCE_TYPES = gql`
 
 const PoolsPage: VoidFunctionComponent = () => {
   const [selectedTags, { handleOnTagClick, clearAllTags }] = useTags();
-  const [selectedResourceType, setSelectedResourceType] = useState<string>('');
+  const [selectedResourceType, setSelectedResourceType] = useState<string>('Select resource type to filter');
   const context = useMemo(() => ({ additionalTypenames: ['ResourcePool'] }), []);
   const [{ data, fetching: isQueryLoading, error }] = useQuery<GetPoolsQuery, GetPoolsQueryVariables>({
     query: ALL_POOLS_QUERY,
@@ -108,7 +108,7 @@ const PoolsPage: VoidFunctionComponent = () => {
   const handleOnClearSearch = () => {
     setSearchText('');
     clearAllTags();
-    setSelectedResourceType('');
+    setSelectedResourceType('Select resource type to filter');
   };
 
   const handleOnStrategyClick = (id?: string) => {
@@ -125,7 +125,7 @@ const PoolsPage: VoidFunctionComponent = () => {
     return <div>{error?.message}</div>;
   }
 
-  const isSelectedResourceTypeEmpty = selectedResourceType == null || selectedResourceType.trim().length === 0;
+  const isSelectedResourceTypeEmpty = selectedResourceType === 'Select resource type to filter';
 
   const resourcePools = results.filter((pool) => {
     if (!isSelectedResourceTypeEmpty && selectedTags.length > 0) {

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
@@ -71,7 +71,7 @@ const GET_RESOURCE_TYPES = gql`
 
 const PoolsPage: VoidFunctionComponent = () => {
   const [selectedTags, { handleOnTagClick, clearAllTags }] = useTags();
-  const [selectedResourceType, setSelectedResourceType] = useState<string>('Select resource type to filter');
+  const [selectedResourceType, setSelectedResourceType] = useState<string>('');
   const context = useMemo(() => ({ additionalTypenames: ['ResourcePool'] }), []);
   const [{ data, fetching: isQueryLoading, error }] = useQuery<GetPoolsQuery, GetPoolsQueryVariables>({
     query: ALL_POOLS_QUERY,
@@ -108,7 +108,7 @@ const PoolsPage: VoidFunctionComponent = () => {
   const handleOnClearSearch = () => {
     setSearchText('');
     clearAllTags();
-    setSelectedResourceType('Select resource type to filter');
+    setSelectedResourceType('');
   };
 
   const handleOnStrategyClick = (id?: string) => {
@@ -125,7 +125,7 @@ const PoolsPage: VoidFunctionComponent = () => {
     return <div>{error?.message}</div>;
   }
 
-  const isSelectedResourceTypeEmpty = selectedResourceType === 'Select resource type to filter';
+  const isSelectedResourceTypeEmpty = selectedResourceType === null || selectedResourceType.trim().length === 0;
 
   const resourcePools = results.filter((pool) => {
     if (!isSelectedResourceTypeEmpty && selectedTags.length > 0) {

--- a/packages/shared/src/hooks/use-minisearch.ts
+++ b/packages/shared/src/hooks/use-minisearch.ts
@@ -6,6 +6,7 @@ type Item<T> = T & { Name: string };
 
 function getFilteredResults<T extends { Name: string }>(searchResult: SearchResult[], items: T[]): T[] {
   const itemsMap = new Map(items.map((item) => [item.Name, item]));
+
   return compact(
     searchResult.map((r) => {
       return itemsMap.get(r.id);
@@ -32,13 +33,12 @@ const useMinisearch = <T>({
       if (searchText != null) {
         return getFilteredResults(minisearch.search(searchText, { prefix: true }), items || []);
       }
-
       return [];
     }, 80)();
 
-  useEffect(() => minisearch.addAll(items || []), []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => minisearch.addAll(items || []), [items]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const results = searchText && searchText.length > 2 ? searchFn() : items;
+  const results = searchText.length > 0 ? searchFn() : items;
 
   return {
     results: results || [],


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-465` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->

https://frinxhelpdesk.atlassian.net/browse/FD-465?atlOrigin=eyJpIjoiNmI4OGYyZDA5MmFhNGRhNmE4MWYxNTE5MmU5Yjk1ZjQiLCJwIjoiaiJ9

Filtering by name was not working unless you opened pool config page and returned with browser back button wich had it cached. Added "items" dependency to useEffect of use-minisearch hook that fixed the issue.

Also fixed filtering by resource type. When selecting for example ipv4, search results were correct but when switching back to default search option no results were listed
