### PR TITLE
fix random_signed_int32 pool property inputs

### DIFF
--- a/packages/frinx-resource-manager/src/pages/create-pool-page/pool-properties-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-pool-page/pool-properties-form.tsx
@@ -63,7 +63,7 @@ const PoolPropertyInput = ({
 
   return (
     <Input
-      type={shouldBeNumber? "number" : "text" }
+      type={shouldBeNumber ? 'number' : 'text'}
       data-cy={`device-state-${pKey}`}
       placeholder={placeholder}
       name={pKey}

--- a/packages/frinx-resource-manager/src/pages/create-pool-page/pool-properties-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-pool-page/pool-properties-form.tsx
@@ -63,6 +63,7 @@ const PoolPropertyInput = ({
 
   return (
     <Input
+      type={shouldBeNumber? "number" : "text" }
       data-cy={`device-state-${pKey}`}
       placeholder={placeholder}
       name={pKey}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-466` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->
https://frinxhelpdesk.atlassian.net/browse/FD-466?atlOrigin=eyJpIjoiYzlhYzI0NWVkZDE2NGI0ZWFkZmUxYTIyYTJjYjQyNWMiLCJwIjoiaiJ9

random_signed_int32 resource type input fields ( from, to ) can now accept negative number values without writing them as positive first and adding negative sign before them

