### PR TITLE
Update interface behaviour

### DIFF
--- a/packages/frinx-device-topology/api.graphql
+++ b/packages/frinx-device-topology/api.graphql
@@ -301,6 +301,7 @@ input GraphNodeCoordinatesInput {
 
 type GraphNodeInterface {
   id: String!
+  name: String!
   status: GraphEdgeStatus!
 }
 

--- a/packages/frinx-device-topology/src/__generated__/graphql.ts
+++ b/packages/frinx-device-topology/src/__generated__/graphql.ts
@@ -353,6 +353,7 @@ export type GraphNodeCoordinatesInput = {
 export type GraphNodeInterface = {
   __typename?: 'GraphNodeInterface';
   id: Scalars['String'];
+  name: Scalars['String'];
   status: GraphEdgeStatus;
 };
 
@@ -869,7 +870,7 @@ export type TopologyVersionDataQueryQueryVariables = Exact<{
 }>;
 
 
-export type TopologyVersionDataQueryQuery = { __typename?: 'Query', topologyVersionData: { __typename?: 'TopologyVersionData', edges: Array<{ __typename?: 'GraphVersionEdge', id: string, source: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string }, target: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string } }>, nodes: Array<{ __typename?: 'GraphVersionNode', id: string, name: string, interfaces: Array<{ __typename?: 'GraphNodeInterface', id: string, status: GraphEdgeStatus }>, coordinates: { __typename?: 'GraphNodeCoordinates', x: number, y: number } }> } };
+export type TopologyVersionDataQueryQuery = { __typename?: 'Query', topologyVersionData: { __typename?: 'TopologyVersionData', edges: Array<{ __typename?: 'GraphVersionEdge', id: string, source: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string }, target: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string } }>, nodes: Array<{ __typename?: 'GraphVersionNode', id: string, name: string, interfaces: Array<{ __typename?: 'GraphNodeInterface', id: string, status: GraphEdgeStatus, name: string }>, coordinates: { __typename?: 'GraphNodeCoordinates', x: number, y: number } }> } };
 
 export type UpdatePositionMutationVariables = Exact<{
   input: Array<GraphNodeCoordinatesInput> | GraphNodeCoordinatesInput;
@@ -890,4 +891,4 @@ export type TopologyQueryVariables = Exact<{
 }>;
 
 
-export type TopologyQuery = { __typename?: 'Query', topology: { __typename?: 'Topology', nodes: Array<{ __typename?: 'GraphNode', id: string, deviceType: string | null, softwareVersion: string | null, device: { __typename?: 'Device', id: string, name: string, deviceSize: DeviceSize }, interfaces: Array<{ __typename?: 'GraphNodeInterface', id: string, status: GraphEdgeStatus }>, coordinates: { __typename?: 'GraphNodeCoordinates', x: number, y: number } }>, edges: Array<{ __typename?: 'GraphEdge', id: string, source: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string }, target: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string } }> } | null };
+export type TopologyQuery = { __typename?: 'Query', topology: { __typename?: 'Topology', nodes: Array<{ __typename?: 'GraphNode', id: string, deviceType: string | null, softwareVersion: string | null, device: { __typename?: 'Device', id: string, name: string, deviceSize: DeviceSize }, interfaces: Array<{ __typename?: 'GraphNodeInterface', id: string, status: GraphEdgeStatus, name: string }>, coordinates: { __typename?: 'GraphNodeCoordinates', x: number, y: number } }>, edges: Array<{ __typename?: 'GraphEdge', id: string, source: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string }, target: { __typename?: 'EdgeSourceTarget', nodeId: string, interface: string } }> } | null };

--- a/packages/frinx-device-topology/src/components/edge/edge.helpers.ts
+++ b/packages/frinx-device-topology/src/components/edge/edge.helpers.ts
@@ -1,6 +1,18 @@
 import { Change } from '../../helpers/topology-helpers';
 
-export function getEdgeColor(change: Change) {
+export function getEdgeColor(change: Change, isUnknown: boolean): string {
+  if (isUnknown) {
+    if (change === 'DELETED') {
+      return 'red.200';
+    }
+    if (change === 'ADDED') {
+      return 'green.200';
+    }
+    if (change === 'UPDATED') {
+      return 'yellow.200';
+    }
+    return 'gray.200';
+  }
   if (change === 'DELETED') {
     return 'red.400';
   }

--- a/packages/frinx-device-topology/src/components/edge/edge.tsx
+++ b/packages/frinx-device-topology/src/components/edge/edge.tsx
@@ -2,7 +2,7 @@ import { Box, Theme, useTheme } from '@chakra-ui/react';
 import get from 'lodash/get';
 import React, { VoidFunctionComponent } from 'react';
 import { GraphEdgeWithDiff } from '../../helpers/topology-helpers';
-import { getAngleBetweenPoints, getCurvePath, Line, Position } from '../../pages/topology/graph.helpers';
+import { getCurvePath, Line, Position } from '../../pages/topology/graph.helpers';
 import { getEdgeColor } from './edge.helpers';
 
 type Props = {
@@ -26,7 +26,6 @@ const Edge: VoidFunctionComponent<Props> = ({
 }) => {
   const { start, end } = linePoints;
   const { colors } = useTheme<Theme>();
-  const angle = getAngleBetweenPoints(start, end);
 
   return (
     <>

--- a/packages/frinx-device-topology/src/components/edge/edge.tsx
+++ b/packages/frinx-device-topology/src/components/edge/edge.tsx
@@ -2,7 +2,7 @@ import { Box, Theme, useTheme } from '@chakra-ui/react';
 import get from 'lodash/get';
 import React, { VoidFunctionComponent } from 'react';
 import { GraphEdgeWithDiff } from '../../helpers/topology-helpers';
-import { getCurvePath, Line, Position } from '../../pages/topology/graph.helpers';
+import { getAngleBetweenPoints, getCurvePath, Line, Position } from '../../pages/topology/graph.helpers';
 import { getEdgeColor } from './edge.helpers';
 
 type Props = {
@@ -26,6 +26,7 @@ const Edge: VoidFunctionComponent<Props> = ({
 }) => {
   const { start, end } = linePoints;
   const { colors } = useTheme<Theme>();
+  const angle = getAngleBetweenPoints(start, end);
 
   return (
     <>
@@ -33,12 +34,11 @@ const Edge: VoidFunctionComponent<Props> = ({
         <g>
           <path
             strokeWidth={1}
-            stroke={get(colors, getEdgeColor(edge.change))}
+            stroke={get(colors, getEdgeColor(edge.change, isUnknown))}
             strokeLinejoin="round"
             fill="none"
             d={getCurvePath(start, end, controlPoints)}
             cursor="pointer"
-            opacity={isUnknown ? 0.5 : 1}
           />
           <path
             strokeWidth={5}
@@ -51,7 +51,6 @@ const Edge: VoidFunctionComponent<Props> = ({
             onClick={() => {
               onClick(edge);
             }}
-            opacity={isUnknown ? 0.5 : 1}
           />
         </g>
       ) : (
@@ -61,12 +60,11 @@ const Edge: VoidFunctionComponent<Props> = ({
           y1={start.y}
           x2={end.x}
           y2={end.y}
-          stroke={getEdgeColor(edge.change)}
+          stroke={getEdgeColor(edge.change, isUnknown)}
           strokeWidth={isActive ? 3 : 1}
           strokeLinecap="round"
           borderWidth={3}
           transition="all .2s ease-in-out"
-          strokeDasharray={isUnknown ? '15, 15' : undefined}
         />
       )}
 

--- a/packages/frinx-device-topology/src/components/edge/edge.tsx
+++ b/packages/frinx-device-topology/src/components/edge/edge.tsx
@@ -8,81 +8,52 @@ import { getEdgeColor } from './edge.helpers';
 type Props = {
   edge: GraphEdgeWithDiff;
   isActive: boolean;
-  isSelected: boolean;
   controlPoints: Position[];
   linePoints: Line;
   onClick: (edge: GraphEdgeWithDiff | null) => void;
   isUnknown: boolean;
 };
 
-const Edge: VoidFunctionComponent<Props> = ({
-  edge,
-  isActive,
-  isSelected,
-  controlPoints,
-  linePoints,
-  onClick,
-  isUnknown,
-}) => {
+const Edge: VoidFunctionComponent<Props> = ({ edge, isActive, controlPoints, linePoints, onClick, isUnknown }) => {
   const { start, end } = linePoints;
   const { colors } = useTheme<Theme>();
 
-  return (
-    <>
-      {isActive ? (
-        <g>
-          <path
-            strokeWidth={1}
-            stroke={get(colors, getEdgeColor(edge.change, isUnknown))}
-            strokeLinejoin="round"
-            fill="none"
-            d={getCurvePath(start, end, controlPoints)}
-            cursor="pointer"
-          />
-          <path
-            strokeWidth={5}
-            stroke="transparent"
-            strokeLinejoin="round"
-            fill="none"
-            d={getCurvePath(start, end, controlPoints)}
-            cursor="pointer"
-            pointerEvents={edge.change === 'DELETED' ? 'none' : 'all'}
-            onClick={() => {
-              onClick(edge);
-            }}
-          />
-        </g>
-      ) : (
-        <Box
-          as="line"
-          x1={start.x}
-          y1={start.y}
-          x2={end.x}
-          y2={end.y}
-          stroke={getEdgeColor(edge.change, isUnknown)}
-          strokeWidth={isActive ? 3 : 1}
-          strokeLinecap="round"
-          borderWidth={3}
-          transition="all .2s ease-in-out"
-        />
-      )}
-
-      {isSelected && (
-        <>
-          <defs>
-            <path id="sourcePath" d={getCurvePath(start, end, controlPoints)} />
-          </defs>
-          <text dx={30} dy={20} fontSize={14}>
-            <textPath href="#sourcePath">{edge.source.interface}</textPath>
-          </text>
-          <text dx={-30} dy={-10} fontSize={14}>
-            <textPath href="#sourcePath" startOffset="100%" textAnchor="end">
-              {edge.target.interface}
-            </textPath>
-          </text>
-        </>
-      )}
-    </>
+  return isActive ? (
+    <g>
+      <path
+        strokeWidth={1}
+        stroke={get(colors, getEdgeColor(edge.change, isUnknown))}
+        strokeLinejoin="round"
+        fill="none"
+        d={getCurvePath(start, end, controlPoints)}
+        cursor="pointer"
+      />
+      <path
+        strokeWidth={5}
+        stroke="transparent"
+        strokeLinejoin="round"
+        fill="none"
+        d={getCurvePath(start, end, controlPoints)}
+        cursor="pointer"
+        pointerEvents={edge.change === 'DELETED' ? 'none' : 'all'}
+        onClick={() => {
+          onClick(edge);
+        }}
+      />
+    </g>
+  ) : (
+    <Box
+      as="line"
+      x1={start.x}
+      y1={start.y}
+      x2={end.x}
+      y2={end.y}
+      stroke={getEdgeColor(edge.change, isUnknown)}
+      strokeWidth={isActive ? 3 : 1}
+      strokeLinecap="round"
+      borderWidth={3}
+      transition="all .2s ease-in-out"
+    />
   );
 };
 

--- a/packages/frinx-device-topology/src/components/node-icon/node-icon.tsx
+++ b/packages/frinx-device-topology/src/components/node-icon/node-icon.tsx
@@ -3,6 +3,7 @@ import React, { PointerEvent, VoidFunctionComponent } from 'react';
 import { GraphNodeWithDiff } from '../../helpers/topology-helpers';
 import { PositionsWithGroupsMap } from '../../pages/topology/graph.helpers';
 import { TopologyMode } from '../../state.actions';
+import { GraphEdge } from '../../__generated__/graphql';
 import {
   getDeviceNodeTransformProperties,
   getNodeBackgroundColor,
@@ -22,6 +23,7 @@ type Props = {
   onPointerDown: (event: PointerEvent<SVGRectElement>) => void;
   onPointerMove: (event: PointerEvent<SVGRectElement>) => void;
   onPointerUp: (event: PointerEvent<SVGRectElement>) => void;
+  selectedEdge: GraphEdge | null;
 };
 
 const G = chakra('g');
@@ -39,11 +41,14 @@ const NodeIcon: VoidFunctionComponent<Props> = ({
   onPointerDown,
   onPointerMove,
   onPointerUp,
+  selectedEdge,
 }) => {
   const { device, change } = node;
   const { x, y } = positions.nodes[node.device.name];
   const interfaceGroups = getNodeInterfaceGroups(device.name, positions.interfaceGroups);
   const { circleDiameter, sizeTransform } = getDeviceNodeTransformProperties(node.device.deviceSize);
+
+  // console.log(selectedEdge, isSelected, node.device.name);
 
   return (
     <G
@@ -62,21 +67,6 @@ const NodeIcon: VoidFunctionComponent<Props> = ({
         transition="all .2s ease-in-out"
       />
       <G>
-        <G>
-          {interfaceGroups.map(([groupId, data]) => {
-            const iPosition = data.position;
-            return iPosition ? (
-              <Circle
-                r="4px"
-                fill="purple"
-                key={groupId}
-                style={{
-                  transform: isFocused ? `translate3d(${iPosition.x - x}px, ${iPosition.y - y}px, 0)` : undefined,
-                }}
-              />
-            ) : null;
-          })}
-        </G>
         <Circle
           r={`${circleDiameter / 2}px`}
           fill={getNodeBackgroundColor({ isSelected, change })}
@@ -129,6 +119,31 @@ const NodeIcon: VoidFunctionComponent<Props> = ({
           stroke="green.300"
         />
       )}
+      <G>
+        {interfaceGroups.map(([groupId, data]) => {
+          const iPosition = data.position;
+          const sourceInterface = data.interfaces.find((i) => i.id === selectedEdge?.source.interface);
+          const targetInterface = data.interfaces.find((i) => i.id === selectedEdge?.target.interface);
+          return iPosition ? (
+            <G
+              transform={isFocused ? `translate3d(${iPosition.x - x}px, ${iPosition.y - y}px, 0)` : undefined}
+              opacity={isFocused ? 1 : 0}
+            >
+              {sourceInterface != null && (
+                <Text fontSize="sm" transform="translate(5px, -5px)">
+                  {sourceInterface?.name}
+                </Text>
+              )}
+              {targetInterface != null && (
+                <Text fontSize="sm" transform="translate(5px, -5px)">
+                  {targetInterface?.name}
+                </Text>
+              )}
+              <Circle r="4px" fill="purple" key={groupId} />
+            </G>
+          ) : null;
+        })}
+      </G>
     </G>
   );
 };

--- a/packages/frinx-device-topology/src/components/node-icon/node-icon.tsx
+++ b/packages/frinx-device-topology/src/components/node-icon/node-icon.tsx
@@ -130,13 +130,21 @@ const NodeIcon: VoidFunctionComponent<Props> = ({
               opacity={isFocused ? 1 : 0}
             >
               {sourceInterface != null && (
-                <Text fontSize="sm" transform="translate(5px, -5px)">
-                  {sourceInterface?.name}
+                <Text
+                  fontSize="sm"
+                  transform="translate(5px, -5px)"
+                  fill={sourceInterface.status === 'unknown' ? 'red' : 'black'}
+                >
+                  {sourceInterface.name}
                 </Text>
               )}
               {targetInterface != null && (
-                <Text fontSize="sm" transform="translate(5px, -5px)">
-                  {targetInterface?.name}
+                <Text
+                  fontSize="sm"
+                  transform="translate(5px, -5px)"
+                  fill={targetInterface.status === 'unknown' ? 'red' : 'black'}
+                >
+                  {targetInterface.name}
                 </Text>
               )}
               <Circle r="4px" fill="purple" key={groupId} />

--- a/packages/frinx-device-topology/src/components/node-icon/node-icon.tsx
+++ b/packages/frinx-device-topology/src/components/node-icon/node-icon.tsx
@@ -48,8 +48,6 @@ const NodeIcon: VoidFunctionComponent<Props> = ({
   const interfaceGroups = getNodeInterfaceGroups(device.name, positions.interfaceGroups);
   const { circleDiameter, sizeTransform } = getDeviceNodeTransformProperties(node.device.deviceSize);
 
-  // console.log(selectedEdge, isSelected, node.device.name);
-
   return (
     <G
       cursor={topologyMode === 'COMMON_NODES' ? 'not-allowed' : 'pointer'}

--- a/packages/frinx-device-topology/src/components/version-select/version-select.tsx
+++ b/packages/frinx-device-topology/src/components/version-select/version-select.tsx
@@ -38,6 +38,7 @@ const TOPOLOGY_VERSION_DATA_QUERY = gql`
         interfaces {
           id
           status
+          name
         }
         coordinates {
           x

--- a/packages/frinx-device-topology/src/components/version-select/version-select.tsx
+++ b/packages/frinx-device-topology/src/components/version-select/version-select.tsx
@@ -112,7 +112,7 @@ const VersionSelect: VoidFunctionComponent = () => {
 
   return (
     <>
-      <FormLabel marginBottom={4}>Compare with:</FormLabel>
+      <FormLabel marginBottom={4}>Compare current topology with:</FormLabel>
       <Select value={selectedVersion || undefined} onChange={handleSelectVersionChange} background="white">
         <option value="none">None</option>
         {versions.map((v) => (

--- a/packages/frinx-device-topology/src/pages/topology/edges.tsx
+++ b/packages/frinx-device-topology/src/pages/topology/edges.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const Edges: VoidFunctionComponent<Props> = ({ edgesWithDiff }) => {
   const { state, dispatch } = useStateContext();
-  const { nodePositions, interfaceGroupPositions, connectedNodeIds, selectedNode, selectedEdge, nodes } = state;
+  const { nodePositions, interfaceGroupPositions, connectedNodeIds, selectedNode, nodes } = state;
 
   const handleEdgeClick = (edge: GraphEdgeWithDiff | null) => {
     dispatch(setSelectedEdge(edge));
@@ -29,7 +29,6 @@ const Edges: VoidFunctionComponent<Props> = ({ edgesWithDiff }) => {
         }
 
         const isActive = !!selectedNode?.interfaces.find((i) => i.id === edge.source.interface);
-        const isSelected = edge.id === selectedEdge?.id;
 
         const linePoints = getLinePoints({ edge, connectedNodeIds, nodePositions, interfaceGroupPositions });
         if (!linePoints) {
@@ -56,7 +55,6 @@ const Edges: VoidFunctionComponent<Props> = ({ edgesWithDiff }) => {
             controlPoints={controlPoints}
             edge={edge}
             isActive={isActive ?? false}
-            isSelected={isSelected}
             linePoints={linePoints}
             onClick={handleEdgeClick}
             key={edge.id}

--- a/packages/frinx-device-topology/src/pages/topology/graph.helpers.ts
+++ b/packages/frinx-device-topology/src/pages/topology/graph.helpers.ts
@@ -22,6 +22,7 @@ export type Device = {
 export type GraphNodeInterface = {
   id: string;
   status: 'ok' | 'unknown';
+  name: string;
 };
 export type GraphNode = {
   id: string;

--- a/packages/frinx-device-topology/src/pages/topology/nodes.tsx
+++ b/packages/frinx-device-topology/src/pages/topology/nodes.tsx
@@ -29,6 +29,7 @@ const Nodes: VoidFunctionComponent<Props> = ({ nodesWithDiff, onNodePositionUpda
     unconfirmedSelectedNodeIds,
     mode,
     commonNodeIds,
+    selectedEdge,
   } = state;
   const [position, setPosition] = useState<StatePosition>({
     nodeId: null,
@@ -107,6 +108,7 @@ const Nodes: VoidFunctionComponent<Props> = ({ nodesWithDiff, onNodePositionUpda
           isCommon={commonNodeIds.includes(node.device.name)}
           topologyMode={mode}
           node={node}
+          selectedEdge={selectedEdge}
         />
       ))}
     </g>

--- a/packages/frinx-device-topology/src/pages/topology/topology-graph.tsx
+++ b/packages/frinx-device-topology/src/pages/topology/topology-graph.tsx
@@ -110,7 +110,7 @@ const TopologyGraph: FunctionComponent<Props> = ({
           />
         </Box>
       )}
-      {unconfirmedSelectedNodeIds.length && (
+      {!!unconfirmedSelectedNodeIds.length && (
         <Box position="absolute" top={2} left="2" background="transparent">
           <Button onClick={handleClearCommonSearch}>Clear common search</Button>
           <Button onClick={handleSearchClick} isDisabled={isCommonNodesFetching}>

--- a/packages/frinx-device-topology/src/state.provider.tsx
+++ b/packages/frinx-device-topology/src/state.provider.tsx
@@ -20,6 +20,7 @@ const TOPOLOGY_QUERY = gql`
         interfaces {
           id
           status
+          name
         }
         coordinates {
           x


### PR DESCRIPTION
Use new `name` field in `interface` to display.
Fix interface name label position (previously often displayed upside down).