### PR TITLE
make all active edges clickable

### DIFF
--- a/packages/frinx-device-topology/src/components/edge/edge.tsx
+++ b/packages/frinx-device-topology/src/components/edge/edge.tsx
@@ -35,7 +35,7 @@ const Edge: VoidFunctionComponent<Props> = ({ edge, isActive, controlPoints, lin
         fill="none"
         d={getCurvePath(start, end, controlPoints)}
         cursor="pointer"
-        pointerEvents={edge.change === 'DELETED' ? 'none' : 'all'}
+        pointerEvents={edge.change === 'DELETED' ? 'none' : 'stroke'}
         onClick={() => {
           onClick(edge);
         }}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | None <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->
between nodes PE_XR01 <-> PE_XR02 there are 4 active nodes, but they are not all clickable because the fill area is overlapping (check the main branch). in this PR only stroke area is clickable, so no overlapping anymore 
