### PR TITLE
fix green nodes/edges flash after version change; fix bug with incorr…

### DIFF
--- a/packages/frinx-device-topology/src/components/version-select/version-select.tsx
+++ b/packages/frinx-device-topology/src/components/version-select/version-select.tsx
@@ -82,8 +82,8 @@ const VersionSelect: VoidFunctionComponent = () => {
     if (backupVersionData != null) {
       dispatch(
         setBackupNodesAndEdges({
-          nodes: backupVersionData?.topologyVersionData.nodes || [],
-          edges: backupVersionData?.topologyVersionData.edges || [],
+          nodes: backupVersionData?.topologyVersionData.nodes ?? [],
+          edges: backupVersionData?.topologyVersionData.edges ?? [],
         }),
       );
     }

--- a/packages/frinx-device-topology/src/helpers/topology-helpers.ts
+++ b/packages/frinx-device-topology/src/helpers/topology-helpers.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { GraphNode, BackupGraphNode, GraphEdge, getRandomInt } from '../pages/topology/graph.helpers';
+import { BackupGraphNode, getRandomInt, GraphEdge, GraphNode } from '../pages/topology/graph.helpers';
 
 export type Change = 'ADDED' | 'DELETED' | 'UPDATED' | 'NONE';
 
@@ -12,6 +12,12 @@ export type GraphEdgeWithDiff = GraphEdge & {
 };
 
 export function getNodesWithDiff(nodes: GraphNode[], backupGraphNodes: BackupGraphNode[]): GraphNodeWithDiff[] {
+  if (backupGraphNodes.length === 0) {
+    return nodes.map((n) => ({
+      ...n,
+      change: 'NONE' as const,
+    }));
+  }
   const nodesMap = new Map(nodes.map((n) => [n.id, n]));
   const backupNodesMap = new Map(backupGraphNodes.map((n) => [n.id, n]));
   const currentNodesWithDiff = nodes.map((n) => {
@@ -20,12 +26,11 @@ export function getNodesWithDiff(nodes: GraphNode[], backupGraphNodes: BackupGra
         ...n,
         change: 'NONE' as const,
       };
-    } else {
-      return {
-        ...n,
-        change: 'ADDED' as const,
-      };
     }
+    return {
+      ...n,
+      change: 'ADDED' as const,
+    };
   });
 
   const deletedBackupNodesWithDiff: GraphNodeWithDiff[] = backupGraphNodes
@@ -52,20 +57,25 @@ export function getNodesWithDiff(nodes: GraphNode[], backupGraphNodes: BackupGra
 }
 
 export function getEdgesWithDiff(edges: GraphEdge[], backupEdges: GraphEdge[]): GraphEdgeWithDiff[] {
+  if (backupEdges.length === 0) {
+    return edges.map((e) => ({
+      ...e,
+      change: 'NONE' as const,
+    }));
+  }
   const edgesMap = new Map(edges.map((e) => [e.id, e]));
-  const backupEdgesMap = new Map(edges.map((e) => [e.id, e]));
+  const backupEdgesMap = new Map(backupEdges.map((e) => [e.id, e]));
   const currentEdgesWithDiff = edges.map((e) => {
     if (backupEdgesMap.has(e.id)) {
       return {
         ...e,
         change: 'NONE' as const,
       };
-    } else {
-      return {
-        ...e,
-        change: 'ADDED' as const,
-      };
     }
+    return {
+      ...e,
+      change: 'ADDED' as const,
+    };
   });
 
   const deletedBackupEdgesWithDiff = backupEdges


### PR DESCRIPTION
- fix flash of all green nodes/edges after version change.
- fix incorrect added edge handling

HOW TO TEST:
- open device topology
- change version to see diff
- you shouldn't see nodes/edges flashing green
- you should see one edge correctly marked ass added (the on coming to added, green, node)
