### PR TITLE
fix-resource-manager-whitescreen

### DIFF
--- a/packages/shared/src/hooks/use-minisearch.ts
+++ b/packages/shared/src/hooks/use-minisearch.ts
@@ -36,10 +36,11 @@ const useMinisearch = <T>({
       return [];
     }, 80)();
 
-  useEffect(() => minisearch.addAll(items || []), [items]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    minisearch.removeAll(), minisearch.addAll(items || []);
+  }, [items]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const results = searchText.length > 0 ? searchFn() : items;
-
   return {
     results: results || [],
     searchText,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-243` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

https://frinxhelpdesk.atlassian.net/browse/GAM-243

On deletion of resource pool a whitescreen appeared due to duplicate values sent to minisearch. Fixed by removing the values before reassigning them on items change.
