### PR TITLE
fix-wf-builder-label

### DIFF
--- a/packages/frinx-workflow-builder/src/components/workflow-form/workflow-form.tsx
+++ b/packages/frinx-workflow-builder/src/components/workflow-form/workflow-form.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import {
   Box,
   Button,
@@ -118,6 +118,11 @@ const WorkflowForm: FC<Props> = ({
   };
 
   const tagsInput = useTagsInput();
+  console.log(values.labels, tagsInput.selectedTags);
+
+  useEffect(() => {
+    setFieldValue('labels', tagsInput.selectedTags);
+  }, [tagsInput.selectedTags]);
 
   const handleOnChange = (e: React.ChangeEvent) => {
     handleChange(e);
@@ -149,7 +154,6 @@ const WorkflowForm: FC<Props> = ({
           selectedTags={tagsInput.selectedTags}
           onTagCreate={(value) => {
             tagsInput.handleTagCreation(value);
-            setFieldValue('labels', tagsInput.selectedTags);
           }}
           onSelectionChange={tagsInput.handleOnSelectionChange}
         />


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-511` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
When creating labels in wf creation form, label would save only after adding another label, yet the second label would not be still added. Fixed by adding useEffect with dependency array of tagsInput.selectedTags 