### PR TITLE
fixed rednering of failed workflows

### DIFF
--- a/packages/frinx-workflow-ui/src/pages/executed-workflow-detail/task-table.tsx
+++ b/packages/frinx-workflow-ui/src/pages/executed-workflow-detail/task-table.tsx
@@ -24,7 +24,7 @@ const TaskTable: FC<Props> = ({ tasks, onTaskClick, formatDate }) => (
     </Thead>
     <Tbody>
       {tasks.map((task) => (
-        <Tr key={task.referenceTaskName}>
+        <Tr key={task.taskId}>
           <Td>{task.seq}</Td>
           <Td
             onClick={() => {

--- a/packages/shared/src/helpers/workflow-api.types.ts
+++ b/packages/shared/src/helpers/workflow-api.types.ts
@@ -362,6 +362,7 @@ export type ExecutedWorkflowTask = {
   subWorkflowId: string;
   startTime: number;
   endTime: number;
+  taskId?: string;
   externalOutputPayloadStoragePath?: string;
   externalInputPayloadStoragePath?: string;
 };


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-509` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

https://frinxhelpdesk.atlassian.net/browse/FD-509?atlOrigin=eyJpIjoiNzIwZWExZDM5NmQ3NGFkYmFmNDM4MWNmMGQwZmE1NWQiLCJwIjoiaiJ9

fixed rednering of failed workflows by switching key of table row from referenceTaskName to taskId as it was cousing the bug because all failed tasks had the samereferenceTaskName and therefore multiple rows had the same key

HOW TO TEST
open any executed workflow that has children, "Retry" and then click any of the tasks, then hit browser "Back" button. Duplicate failed tasks shouldnt be there anymore.