### PR TITLE
fixed filtering by name in ipam ip-ranges and aggregates

### DIFF
--- a/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
+++ b/packages/frinx-resource-manager/src/components/search-filter-pools-bar.tsx
@@ -21,6 +21,7 @@ type Props = {
   onTagClick: (tag: string) => void;
   setSearchName: (value: string) => void;
   canFilterByAllocatedResources?: boolean;
+  searchBy?: string;
 };
 
 const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
@@ -29,7 +30,7 @@ const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
   allocatedResources,
   setAllocatedResources,
   setSearchName,
-
+  searchBy = 'name',
   selectedTags,
   resourceTypes,
   clearAllTags,
@@ -55,7 +56,7 @@ const SearchFilterPoolsBar: VoidFunctionComponent<Props> = ({
     <>
       <HStack mb={5}>
         <Searchbar
-          placeholder="Search by name"
+          placeholder={`Search by ${searchBy}`}
           data-cy="search-by-name"
           value={searchName}
           onChange={(e) => setSearchName(e.target.value)}

--- a/packages/frinx-resource-manager/src/pages/ipam-page/ip-ranges-table.tsx
+++ b/packages/frinx-resource-manager/src/pages/ipam-page/ip-ranges-table.tsx
@@ -49,10 +49,10 @@ const IpRangesTable: VoidFunctionComponent<Props> = ({ ipRanges, onTagClick, fet
       <Table size="sm">
         <Thead bgColor="gray.200">
           <Tr>
+            <Th>Name</Th>
             <Th>Network</Th>
             <Th>Broadcast</Th>
             <Th>Size</Th>
-            <Th>Name</Th>
             <Th>Tags</Th>
             <Th>Actions</Th>
           </Tr>
@@ -64,6 +64,7 @@ const IpRangesTable: VoidFunctionComponent<Props> = ({ ipRanges, onTagClick, fet
               const totalCapacity = BigInt(Number(rest.totalCapacity));
               return (
                 <Tr key={id}>
+                  <Td>{name}</Td>
                   {nestedRanges.length > 0 ? (
                     <Td>
                       <ChakraLink as={Link} textColor="blue" to={`../ipam/ip-ranges/${id}/nested-ranges`}>
@@ -75,7 +76,6 @@ const IpRangesTable: VoidFunctionComponent<Props> = ({ ipRanges, onTagClick, fet
                   )}
                   <Td>{broadcast}</Td>
                   <Td>{new Intl.NumberFormat('fr').format(totalCapacity)}</Td>
-                  <Td>{name}</Td>
                   <Td>
                     {tags.map(({ Tag: tagName, id: tagId }) => (
                       <Tag

--- a/packages/frinx-resource-manager/src/pages/ipam-page/ipam-aggregates-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/ipam-page/ipam-aggregates-page.tsx
@@ -123,10 +123,16 @@ const IpamAggregatesPage: VoidFunctionComponent = () => {
   const { addToastNotification } = useNotifications();
   const { results, setSearchText } = useMinisearch({
     items: allAggregates,
-    searchFields: ['PoolProperties'],
+    searchFields: ['aggregate'],
     extractField: (document, fieldName) => {
-      if (fieldName === 'PoolProperties') {
-        return JSON.stringify(document[fieldName]);
+      if (fieldName === 'aggregate') {
+        const { PoolProperties } = document;
+        const { address, prefix } = PoolProperties;
+        const aggregateInfo = isIpv4(document.ResourceType.Name)
+          ? `${ipaddr.IPv4.networkAddressFromCIDR(`${address}/${prefix}`)}/${prefix}`
+          : `${ipaddr.IPv6.networkAddressFromCIDR(`${address}/${prefix}`)}/${prefix}`;
+
+        return aggregateInfo.toString();
       }
 
       return document[fieldName];
@@ -196,6 +202,7 @@ const IpamAggregatesPage: VoidFunctionComponent = () => {
       </Heading>
       <SearchFilterPoolsBar
         searchName={searchName}
+        searchBy="aggregate"
         setSearchName={setSearchName}
         onSearchClick={onSearchClick}
         clearAllTags={clearAllTags}

--- a/packages/frinx-resource-manager/src/pages/ipam-page/ipam-ip-ranges-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/ipam-page/ipam-ip-ranges-page.tsx
@@ -133,14 +133,6 @@ const IpamIpRangesPage: VoidFunctionComponent = () => {
   const [selectedTags, { clearAllTags, handleOnTagClick }] = useTags();
   const { results, setSearchText } = useMinisearch({
     items: allIpamIpRanges,
-    searchFields: ['Name', 'PoolProperties'],
-    extractField: (document, fieldName) => {
-      if (fieldName === 'PoolProperties') {
-        return JSON.stringify(document[fieldName]);
-      }
-
-      return document[fieldName];
-    },
   });
 
   const handleOnClearSearch = () => {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-539` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

https://frinxhelpdesk.atlassian.net/browse/FD-539?atlOrigin=eyJpIjoiNjVhMTYwNmExOWJiNGRkNWIxMGRlODFiOWI1ZjM5MzMiLCJwIjoiaiJ9

RM -> IPAM -> IP Ranges and Aggregates filter by name

Filtering by name used to filter randomly and weirdly. Fixed so aggregates get filtered by aggregates and IP Ranges get filtered by name