### PR TITLE
fixed nested pool creation

### DIFF
--- a/packages/frinx-resource-manager/src/pages/create-pool-page/create-pool-form.tsx
+++ b/packages/frinx-resource-manager/src/pages/create-pool-page/create-pool-form.tsx
@@ -102,6 +102,8 @@ const CreatePoolForm: VoidFunctionComponent<Props> = ({
   onResourceTypeChange,
   requiredPoolProperties,
 }) => {
+  const [resTypeId, setResTypeId] = useState('');
+
   const navigate = useNavigate();
   const tagsInput = useTagsInput();
   const [validationSchema, setValidationSchema] = useState(
@@ -189,9 +191,9 @@ const CreatePoolForm: VoidFunctionComponent<Props> = ({
     handleChange(e);
     setFieldValue('resourceTypeName', selectedResourceTypeName);
 
-    if (selectedResourceTypeName != null && isCustomResourceType(selectedResourceTypeName)) {
-      onResourceTypeChange(selectedResourceTypeName);
-    }
+    const selectedResourceTypeId = e.target.value;
+    setResTypeId(selectedResourceTypeId);
+    onResourceTypeChange(resTypeId);
   };
 
   const [poolProperties, poolPropertyTypes] = getPoolPropertiesSkeleton(
@@ -228,7 +230,7 @@ const CreatePoolForm: VoidFunctionComponent<Props> = ({
             data-cy="create-pool-type"
             id="resourceType"
             name="resourceTypeId"
-            value={resourceTypeId}
+            value={resTypeId}
             onChange={handleOnResourceTypeChange}
             placeholder="Select resource type"
           >


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-525` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

https://frinxhelpdesk.atlassian.net/browse/FD-525?atlOrigin=eyJpIjoiMmNjM2ZjNDE4MjU2NGQwYTg2YTFjZDU3MDI3ZmNiOGMiLCJwIjoiaiJ9

the problem was with ResourceType selection, UI showed it had prefilled value of some resourceType but if you did not change the default value it would not submit. Changed it so it has default value of "Choose..." so now the user has to pick