### PR TITLE
Fd 552 refresh token

### DIFF
--- a/packages/frinx-api/src/api-helpers.ts
+++ b/packages/frinx-api/src/api-helpers.ts
@@ -45,11 +45,8 @@ export function createApiHelpers(
       },
     });
 
-    console.log('== refresh token: ', refreshToken);
-
     if (refreshToken) {
-      const tokenResponse = await refreshToken();
-      console.log('== refresh token response: ', tokenResponse);
+      await refreshToken();
     }
 
     if (response.status === 401) {

--- a/packages/frinx-api/src/api-helpers.ts
+++ b/packages/frinx-api/src/api-helpers.ts
@@ -25,10 +25,15 @@ export type ApiHelpers = {
 export type ErrorType = 'UNAUTHORIZED' | 'FORBIDDEN' | 'ACCESS_REJECTED';
 export type AuthContext = {
   getAuthToken: () => string | null;
+  setAuthToken: (authToken: string) => void;
   emit: (errorType: ErrorType) => void;
 };
 
-export function createApiHelpers(baseURL: string, authContext: AuthContext): ApiHelpers {
+export function createApiHelpers(
+  baseURL: string,
+  authContext: AuthContext,
+  refreshToken?: () => Promise<string | null>,
+): ApiHelpers {
   async function apiFetch(path: string, options: RequestInit): Promise<unknown> {
     const url = urlJoin(baseURL, path);
     const { headers, ...rest } = options;
@@ -39,6 +44,13 @@ export function createApiHelpers(baseURL: string, authContext: AuthContext): Api
         ...makeHeaders(authContext.getAuthToken(), headers),
       },
     });
+
+    console.log('== refresh token: ', refreshToken);
+
+    if (refreshToken) {
+      const tokenResponse = await refreshToken();
+      console.log('== refresh token response: ', tokenResponse);
+    }
 
     if (response.status === 401) {
       return authContext.emit('UNAUTHORIZED');

--- a/packages/frinx-api/src/types.ts
+++ b/packages/frinx-api/src/types.ts
@@ -4,6 +4,7 @@ import { AuthContext } from './api-helpers';
 export type ApiConfig = {
   url: string;
   authContext: AuthContext;
+  refreshToken?: () => Promise<string | null>;
 };
 
 export type GraphQLApiClient = {

--- a/packages/frinx-api/src/uniflow-api.ts
+++ b/packages/frinx-api/src/uniflow-api.ts
@@ -8,8 +8,8 @@ export default class UniflowApi {
   private static instance: UniflowApi;
 
   private constructor(config: ApiConfig) {
-    const { authContext, url } = config;
-    const apiHelpers = createApiHelpers(url, authContext);
+    const { authContext, url, refreshToken } = config;
+    const apiHelpers = createApiHelpers(url, authContext, refreshToken);
     this.client = createUniflowApiClient(apiHelpers);
   }
 

--- a/packages/frinx-dashboard/src/auth-helpers.ts
+++ b/packages/frinx-dashboard/src/auth-helpers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { PublicClientApplication } from '@azure/msal-browser';
+import { IPublicClientApplication, PublicClientApplication } from '@azure/msal-browser';
 import EventEmitter from 'eventemitter3';
 
 const LS_TOKEN_KEY = 'id_token';

--- a/packages/frinx-dashboard/src/auth-helpers.ts
+++ b/packages/frinx-dashboard/src/auth-helpers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { IPublicClientApplication, PublicClientApplication } from '@azure/msal-browser';
+import { AccountInfo, InteractionStatus, IPublicClientApplication, PublicClientApplication } from '@azure/msal-browser';
 import EventEmitter from 'eventemitter3';
 
 const LS_TOKEN_KEY = 'id_token';
@@ -54,4 +54,26 @@ export function createPublicClientApp(): PublicClientApplication {
     },
   };
   return new PublicClientApplication(authConfig);
+}
+
+export async function refreshToken(
+  inProgress: InteractionStatus,
+  accounts: AccountInfo[],
+  instance: IPublicClientApplication,
+): Promise<string | null> {
+  if (inProgress === 'none' && accounts.length > 0) {
+    try {
+      const authResult = await instance.acquireTokenSilent({
+        account: accounts[0],
+        scopes: ['User.Read'],
+      });
+
+      return authResult.idToken;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log('could not get refreshed token', e);
+    }
+  }
+
+  return null;
 }

--- a/packages/frinx-dashboard/src/auth-provider.tsx
+++ b/packages/frinx-dashboard/src/auth-provider.tsx
@@ -1,4 +1,4 @@
-import { InteractionStatus } from '@azure/msal-browser';
+import { InteractionStatus, IPublicClientApplication } from '@azure/msal-browser';
 import { AuthenticationResult } from '@azure/msal-common';
 import { useMsal } from '@azure/msal-react';
 import { Box, Button, Heading, Text } from '@chakra-ui/react';
@@ -10,6 +10,7 @@ export type ContextType = {
   login: () => Promise<AuthenticationResult>;
   logout: () => Promise<void>;
   inProgress: InteractionStatus;
+  instance: IPublicClientApplication;
 };
 
 export const Context = createContext<ContextType | null>(null);
@@ -66,6 +67,7 @@ const AuthProvider: FC = ({ children }) => {
       logout: () => {
         return instance.logout();
       },
+      instance,
     }),
     [handleLogin, inProgress, instance],
   );

--- a/packages/frinx-dashboard/src/device-topology-app.tsx
+++ b/packages/frinx-dashboard/src/device-topology-app.tsx
@@ -1,10 +1,12 @@
+import { useMsal } from '@azure/msal-react';
 import { InventoryApi } from '@frinx/api';
 import React, { FC, useEffect, useState } from 'react';
-import { authContext } from './auth-helpers';
+import { authContext, refreshToken } from './auth-helpers';
 
 type DeviceTopologyComponents = typeof import('@frinx/device-topology/src');
 const DeviceTopologyApp: FC = () => {
   const [components, setComponents] = useState<DeviceTopologyComponents | null>(null);
+  const { inProgress, accounts, instance } = useMsal();
 
   useEffect(() => {
     import('@frinx/device-topology/src').then((mod) => {
@@ -19,7 +21,10 @@ const DeviceTopologyApp: FC = () => {
   const { InventoryAPIProvider, DeviceTopologyApp: App } = components;
 
   return (
-    <InventoryAPIProvider client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}>
+    <InventoryAPIProvider
+      client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}
+      refreshToken={() => refreshToken(inProgress, accounts, instance)}
+    >
       <App />
     </InventoryAPIProvider>
   );

--- a/packages/frinx-dashboard/src/inventory-app.tsx
+++ b/packages/frinx-dashboard/src/inventory-app.tsx
@@ -1,13 +1,15 @@
+import { useMsal } from '@azure/msal-react';
 import { InventoryApi, UniflowApi } from '@frinx/api';
 import { InventoryApiClient } from '@frinx/inventory-client/src';
 import React, { FC, useEffect, useState } from 'react';
-import { authContext } from './auth-helpers';
+import { authContext, refreshToken } from './auth-helpers';
 
 type InventoryComponents = Omit<typeof import('@frinx/inventory-client/src'), 'getInventoryApiProvider'> & {
-  InventoryAPIProvider: FC<{ client: InventoryApiClient; wsUrl: string }>;
+  InventoryAPIProvider: FC<{ client: InventoryApiClient; wsUrl: string; refreshToken: () => Promise<string | null> }>;
 };
 const InventoryApp: FC = () => {
   const [components, setComponents] = useState<InventoryComponents | null>(null);
+  const { inProgress, accounts, instance } = useMsal();
 
   useEffect(() => {
     import('@frinx/inventory-client/src').then((mod) => {
@@ -30,6 +32,7 @@ const InventoryApp: FC = () => {
     <InventoryAPIProvider
       wsUrl={window.__CONFIG__.inventoryWsURL}
       client={InventoryApi.create({ url: window.__CONFIG__.inventoryApiURL, authContext }).client}
+      refreshToken={() => refreshToken(inProgress, accounts, instance)}
     >
       <App />
     </InventoryAPIProvider>

--- a/packages/frinx-dashboard/src/resource-manager-app.tsx
+++ b/packages/frinx-dashboard/src/resource-manager-app.tsx
@@ -1,33 +1,7 @@
-import { AccountInfo, InteractionStatus, IPublicClientApplication } from '@azure/msal-browser';
 import { useMsal } from '@azure/msal-react';
 import { ResourceManagerApi } from '@frinx/api';
 import React, { FC, useEffect, useState } from 'react';
-import { authContext } from './auth-helpers';
-
-async function getRefreshedToken(
-  inProgress: InteractionStatus,
-  accounts: AccountInfo[],
-  instance: IPublicClientApplication,
-): Promise<string | null> {
-  console.log(inProgress, accounts);
-  if (inProgress === 'none' && accounts.length > 0) {
-    try {
-      console.log(accounts[0]);
-      const authResult = await instance.acquireTokenSilent({
-        account: accounts[0],
-        scopes: ['User.Read'],
-      });
-
-      console.log('authResult: ', authResult.idToken);
-
-      return authResult.idToken || null;
-    } catch (e) {
-      console.log('errors:', e);
-    }
-  }
-
-  return null;
-}
+import { authContext, refreshToken } from './auth-helpers';
 
 const ResourceManagerApp: FC = () => {
   const [components, setComponents] = useState<typeof import('@frinx/resource-manager/src') | null>(null);
@@ -42,14 +16,13 @@ const ResourceManagerApp: FC = () => {
   if (components == null) {
     return null;
   }
-  const refreshToken = () => getRefreshedToken(inProgress, accounts, instance);
 
   const { ResourceManagerAppProvider, ResourceManagerApp: App } = components;
 
   return (
     <ResourceManagerAppProvider
       client={ResourceManagerApi.create({ url: window.__CONFIG__.uniresourceApiURL, authContext }).client}
-      refreshToken={refreshToken}
+      refreshToken={() => refreshToken(inProgress, accounts, instance)}
     >
       <App />
     </ResourceManagerAppProvider>

--- a/packages/frinx-dashboard/src/resource-manager-app.tsx
+++ b/packages/frinx-dashboard/src/resource-manager-app.tsx
@@ -1,9 +1,37 @@
+import { AccountInfo, InteractionStatus, IPublicClientApplication } from '@azure/msal-browser';
+import { useMsal } from '@azure/msal-react';
 import { ResourceManagerApi } from '@frinx/api';
 import React, { FC, useEffect, useState } from 'react';
 import { authContext } from './auth-helpers';
 
+async function getRefreshedToken(
+  inProgress: InteractionStatus,
+  accounts: AccountInfo[],
+  instance: IPublicClientApplication,
+): Promise<string | null> {
+  console.log(inProgress, accounts);
+  if (inProgress === 'none' && accounts.length > 0) {
+    try {
+      console.log(accounts[0]);
+      const authResult = await instance.acquireTokenSilent({
+        account: accounts[0],
+        scopes: ['User.Read'],
+      });
+
+      console.log('authResult: ', authResult.idToken);
+
+      return authResult.idToken || null;
+    } catch (e) {
+      console.log('errors:', e);
+    }
+  }
+
+  return null;
+}
+
 const ResourceManagerApp: FC = () => {
   const [components, setComponents] = useState<typeof import('@frinx/resource-manager/src') | null>(null);
+  const { inProgress, accounts, instance } = useMsal();
 
   useEffect(() => {
     import('@frinx/resource-manager/src').then((mod) => {
@@ -14,12 +42,14 @@ const ResourceManagerApp: FC = () => {
   if (components == null) {
     return null;
   }
+  const refreshToken = () => getRefreshedToken(inProgress, accounts, instance);
 
   const { ResourceManagerAppProvider, ResourceManagerApp: App } = components;
 
   return (
     <ResourceManagerAppProvider
       client={ResourceManagerApi.create({ url: window.__CONFIG__.uniresourceApiURL, authContext }).client}
+      refreshToken={refreshToken}
     >
       <App />
     </ResourceManagerAppProvider>

--- a/packages/frinx-dashboard/src/uniflow-app.tsx
+++ b/packages/frinx-dashboard/src/uniflow-app.tsx
@@ -1,3 +1,5 @@
+import { AccountInfo, InteractionStatus, IPublicClientApplication } from '@azure/msal-browser';
+import { useMsal } from '@azure/msal-react';
 import { UniflowApi } from '@frinx/api';
 import React, { FC, useEffect, useState } from 'react';
 import { authContext } from './auth-helpers';
@@ -9,8 +11,34 @@ type BuilderComponents = {
   BuilderApiProvider: FC;
 };
 
+async function getRefreshedToken(
+  inProgress: InteractionStatus,
+  accounts: AccountInfo[],
+  instance: IPublicClientApplication,
+): Promise<string | null> {
+  console.log(inProgress, accounts);
+  if (inProgress === 'none' && accounts.length > 0) {
+    try {
+      console.log(accounts[0]);
+      const authResult = await instance.acquireTokenSilent({
+        account: accounts[0],
+        scopes: ['User.Read'],
+      });
+
+      console.log('authResult: ', authResult.idToken);
+
+      return authResult.idToken || null;
+    } catch (e) {
+      console.log('errors:', e);
+    }
+  }
+
+  return null;
+}
+
 const UniflowApp: FC = () => {
   const [components, setComponents] = useState<(UniflowComponents & BuilderComponents) | null>(null);
+  const { inProgress, accounts, instance } = useMsal();
 
   useEffect(() => {
     Promise.all([import('@frinx/workflow-ui/src'), import('@frinx/workflow-builder/src')]).then(
@@ -18,13 +46,15 @@ const UniflowApp: FC = () => {
         const { UniflowApp: App, getUniflowApiProvider } = uniflowImport;
         const { getBuilderApiProvider } = builderImport;
 
+        const refreshToken = () => getRefreshedToken(inProgress, accounts, instance);
+
         setComponents({
           UniflowApp: App,
           UniflowApiProvider: getUniflowApiProvider(
-            UniflowApi.create({ url: window.__CONFIG__.uniflowApiURL, authContext }).client,
+            UniflowApi.create({ url: window.__CONFIG__.uniflowApiURL, authContext, refreshToken }).client,
           ),
           BuilderApiProvider: getBuilderApiProvider(
-            UniflowApi.create({ url: window.__CONFIG__.uniflowApiURL, authContext }).client,
+            UniflowApi.create({ url: window.__CONFIG__.uniflowApiURL, authContext, refreshToken }).client,
           ),
         });
       },

--- a/packages/frinx-resource-manager/src/resource-manager-api-provider.tsx
+++ b/packages/frinx-resource-manager/src/resource-manager-api-provider.tsx
@@ -30,8 +30,9 @@ const ResourceManagerApiProvider: FC<Props> = ({ children, client, refreshToken 
         }),
         mapExchange({
           onResult: async (result) => {
-            console.log('== resource manager: refresh token on result');
             refreshToken();
+            // eslint-disable-next-line no-console
+            console.log('== resource manager: refresh token on result');
             return result;
           },
         }),

--- a/packages/frinx-resource-manager/src/resource-manager-api-provider.tsx
+++ b/packages/frinx-resource-manager/src/resource-manager-api-provider.tsx
@@ -1,18 +1,19 @@
-import { cacheExchange, ClientOptions, createClient, dedupExchange, fetchExchange, Provider } from 'urql';
+import { cacheExchange, ClientOptions, createClient, dedupExchange, fetchExchange, mapExchange, Provider } from 'urql';
 import { retryExchange } from '@urql/exchange-retry';
 import React, { FC, useRef } from 'react';
 import { CustomToastProvider } from '@frinx/shared/src';
 import PageContainer from './components/page-container';
 
-export type InventoryApiClient = {
+export type ResourceManagerApiClient = {
   clientOptions: ClientOptions;
   onError: () => void;
 };
 export type Props = {
-  client: InventoryApiClient;
+  client: ResourceManagerApiClient;
+  refreshToken: () => Promise<string | null>;
 };
 
-const ResourceManagerApiProvider: FC<Props> = ({ children, client }) => {
+const ResourceManagerApiProvider: FC<Props> = ({ children, client, refreshToken }) => {
   const { current: urqlClient } = useRef(
     createClient({
       ...client.clientOptions,
@@ -25,6 +26,13 @@ const ResourceManagerApiProvider: FC<Props> = ({ children, client }) => {
               client.onError();
             }
             return false;
+          },
+        }),
+        mapExchange({
+          onResult: async (result) => {
+            console.log('== resource manager: refresh token on result');
+            refreshToken();
+            return result;
           },
         }),
         fetchExchange,


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-552` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->
`acquireTokenSilent` should be call on every api call, to keep accessToken active. this should solve problem, when user is often asked to login

HOW TO TEST:

set these .env variables

```
AUTH_ENABLED=true
AUTH_CLIENT_ID="ping_me_for_details"
AUTH_REDIRECT_DOMAIN="localhost:4000"
AUTH_REDIRECT_SCHEME="https"
```
you should only see som console logs, network request to azure are made only when accessToken is about to expire (5-10min before, i am not sure about expiration time, but assume it is 1hout). before this limit, accessToken is taken from localStorage cache.
