### PR TITLE
remove capacity because of unoptimized calculation at the backend side

### DIFF
--- a/packages/frinx-resource-manager/codegen.yml
+++ b/packages/frinx-resource-manager/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'http://localhost:4000/api/resource'
+schema: 'https://localhost:4000/api/resource'
 documents:
   - './src/**/*.tsx'
   - './src/**/*.ts'

--- a/packages/frinx-resource-manager/package.json
+++ b/packages/frinx-resource-manager/package.json
@@ -32,7 +32,7 @@
     "build": "run-s build:webpack generate:typings",
     "formatter:check": "prettier -l '**/*.ts' '**/*.tsx' '**/*.js' '**/*.jsx' '**/*.json' '**/*.md'",
     "formatter": "prettier --write '**/*.ts' '**/*.tsx' '**/*.js' '**/*.jsx' '**/*.json' '**/*.md'",
-    "codegen": "graphql-codegen --config codegen.yml",
+    "codegen": "NODE_TLS_REJECT_UNAUTHORIZED=0 graphql-codegen --config codegen.yml",
     "codegen:clean": "rm -r src/__generated__",
     "typegen": "tsc --declaration --jsx react --esModuleInterop true --target ESNext --moduleResolution node --outDir dist yup.d.ts src/index.ts"
   },

--- a/packages/frinx-resource-manager/src/__generated__/graphql.ts
+++ b/packages/frinx-resource-manager/src/__generated__/graphql.ts
@@ -10,7 +10,6 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** Represents data-type where variable keys and values can be used */
   Map: any;
 };
 
@@ -724,10 +723,10 @@ export type QueryAllPoolsNestedQueryVariables = Exact<{ [key: string]: never; }>
 
 export type QueryAllPoolsNestedQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, Resources: Array<{ __typename?: 'Resource', id: string, Properties: any, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, Resources: Array<{ __typename?: 'Resource', id: string, Properties: any }> } | null }> }> };
 
-export type QueryAllocationStrategiesQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetAllocationStrategiesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type QueryAllocationStrategiesQuery = { __typename?: 'Query', QueryAllocationStrategies: Array<{ __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string }> };
+export type GetAllocationStrategiesQuery = { __typename?: 'Query', QueryAllocationStrategies: Array<{ __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string }> };
 
 export type GetPoolDetailQueryVariables = Exact<{
   poolId: Scalars['ID'];
@@ -792,7 +791,7 @@ export type GetNestedPoolsDetailQueryVariables = Exact<{
 }>;
 
 
-export type GetNestedPoolsDetailQuery = { __typename?: 'Query', QueryResourcePool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } };
+export type GetNestedPoolsDetailQuery = { __typename?: 'Query', QueryResourcePool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null } };
 
 export type CreateSetPoolMutationVariables = Exact<{
   input: CreateSetPoolInput;
@@ -905,7 +904,7 @@ export type GetPoolsQueryVariables = Exact<{
 }>;
 
 
-export type GetPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, PoolProperties: any, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string, Name: string } | null }>, Capacity: { __typename?: 'PoolCapacityPayload', freeCapacity: string, utilizedCapacity: string } | null }> };
+export type GetPoolsQuery = { __typename?: 'Query', QueryRootResourcePools: Array<{ __typename?: 'ResourcePool', id: string, Name: string, PoolType: PoolType, Tags: Array<{ __typename?: 'Tag', id: string, Tag: string }>, AllocationStrategy: { __typename?: 'AllocationStrategy', id: string, Name: string } | null, ResourceType: { __typename?: 'ResourceType', id: string, Name: string }, Resources: Array<{ __typename?: 'Resource', id: string, NestedPool: { __typename?: 'ResourcePool', id: string } | null }> }> };
 
 export type ResourceTypesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -925,3 +924,13 @@ export type DeleteStrategyMutationVariables = Exact<{
 
 
 export type DeleteStrategyMutation = { __typename?: 'Mutation', DeleteAllocationStrategy: { __typename?: 'DeleteAllocationStrategyPayload', strategy: { __typename?: 'AllocationStrategy', id: string } | null } };
+
+export type AllocationStrategiesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type AllocationStrategiesQuery = { __typename?: 'Query', QueryAllocationStrategies: Array<{ __typename?: 'AllocationStrategy', id: string, Name: string }> };
+
+export type QueryAllocationStrategiesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type QueryAllocationStrategiesQuery = { __typename?: 'Query', QueryAllocationStrategies: Array<{ __typename?: 'AllocationStrategy', id: string, Name: string, Lang: AllocationStrategyLang, Script: string }> };

--- a/packages/frinx-resource-manager/src/components/strategies-list.tsx
+++ b/packages/frinx-resource-manager/src/components/strategies-list.tsx
@@ -4,11 +4,11 @@ import gql from 'graphql-tag';
 import { Button, Flex, Heading, Icon, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
 import FeatherIcon from 'feather-icons-react';
 import DeleteStrategy from './delete-strategy';
-import { QueryAllocationStrategiesQuery } from '../__generated__/graphql';
 import ViewStrategyScript from './view-strategy-script';
+import { GetAllocationStrategiesQuery } from '../__generated__/graphql';
 
 const query = gql`
-  query QueryAllocationStrategies {
+  query GetAllocationStrategies {
     QueryAllocationStrategies {
       id
       Name
@@ -23,7 +23,7 @@ type Props = {
 };
 
 const StrategiesList: FC<Props> = ({ onAddButtonClick }) => {
-  const [result] = useQuery<QueryAllocationStrategiesQuery>({
+  const [result] = useQuery<GetAllocationStrategiesQuery>({
     query,
   });
 

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-page.tsx
@@ -26,12 +26,9 @@ const ALL_POOLS_QUERY = gql`
         id
         Tag
       }
-      PoolProperties
       AllocationStrategy {
         id
         Name
-        Lang
-        Script
       }
       ResourceType {
         id
@@ -41,12 +38,7 @@ const ALL_POOLS_QUERY = gql`
         id
         NestedPool {
           id
-          Name
         }
-      }
-      Capacity {
-        freeCapacity
-        utilizedCapacity
       }
     }
   }

--- a/packages/frinx-resource-manager/src/pages/pools-page/pools-table.tsx
+++ b/packages/frinx-resource-manager/src/pages/pools-page/pools-table.tsx
@@ -1,23 +1,8 @@
-﻿import {
-  Button,
-  HStack,
-  Icon,
-  IconButton,
-  Progress,
-  Table,
-  Tag,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-} from '@chakra-ui/react';
+﻿import { Button, HStack, Icon, IconButton, Table, Tag, Tbody, Td, Text, Th, Thead, Tr } from '@chakra-ui/react';
 import FeatherIcon from 'feather-icons-react';
 import React, { VoidFunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 import DeletePoolPopover from '../../components/delete-modal';
-import { getTotalCapacity } from '../../helpers/resource-pool.helpers';
 import { GetPoolsQuery, Tag as TagType } from '../../__generated__/graphql';
 
 type Props = {
@@ -46,7 +31,6 @@ const PoolsTable: VoidFunctionComponent<Props> = ({
           <Th>Tags</Th>
           <Th>Pool Type</Th>
           <Th>Resource Type</Th>
-          <Th>Utilized Capacity</Th>
           <Th>Actions</Th>
         </Tr>
       </Thead>
@@ -54,14 +38,8 @@ const PoolsTable: VoidFunctionComponent<Props> = ({
         <Tbody>
           {pools.length > 0 ? (
             pools.map((pool) => {
-              const totalCapacity = getTotalCapacity(pool.Capacity);
               const nestedPoolsCount = pool.Resources.filter((resource) => resource.NestedPool != null).length;
               const hasNestedPools = nestedPoolsCount > 0;
-              const progressValue =
-                totalCapacity === 0n
-                  ? 100
-                  : Number((BigInt(pool.Capacity?.utilizedCapacity ?? 0n) * 100n) / totalCapacity);
-
               return (
                 <Tr key={pool.id} opacity={isLoading ? 0.5 : 1} pointerEvents={isLoading ? 'none' : 'all'}>
                   {isNestedShown && (
@@ -111,9 +89,6 @@ const PoolsTable: VoidFunctionComponent<Props> = ({
                     >
                       {pool.ResourceType?.Name}
                     </Text>
-                  </Td>
-                  <Td isNumeric>
-                    <Progress size="xs" value={progressValue} />
                   </Td>
                   <Td>
                     <HStack spacing={2}>

--- a/packages/frinx-resource-manager/src/pages/resource-types-page/resource-types-page.tsx
+++ b/packages/frinx-resource-manager/src/pages/resource-types-page/resource-types-page.tsx
@@ -1,15 +1,15 @@
 import { Flex, Heading, Progress, Text } from '@chakra-ui/react';
 import { useNotifications } from '@frinx/shared/src';
 import gql from 'graphql-tag';
-import React, { useMemo, VoidFunctionComponent, useCallback } from 'react';
+import React, { useCallback, useMemo, VoidFunctionComponent } from 'react';
 import { useMutation, useQuery } from 'urql';
 import {
+  AllocationStrategiesQuery,
   DeleteResourceTypeMutation,
   DeleteResourceTypeMutationVariables,
-  ResourceTypesQuery,
   DeleteStrategyMutation,
   DeleteStrategyMutationVariables,
-  QueryAllocationStrategiesQuery,
+  ResourceTypesQuery,
 } from '../../__generated__/graphql';
 import ResourceTypesTable from './resource-types-table';
 
@@ -41,7 +41,7 @@ const DELETE_STRATEGY_MUTATION = gql`
 `;
 
 const STRATEGIES_QUERY = gql`
-  query QueryAllocationStrategies {
+  query AllocationStrategies {
     QueryAllocationStrategies {
       id
       Name
@@ -63,7 +63,7 @@ const ResourceTypesPage: VoidFunctionComponent = () => {
     context: ctx,
   });
 
-  const [{ data: strategies }] = useQuery<QueryAllocationStrategiesQuery>({
+  const [{ data: strategies }] = useQuery<AllocationStrategiesQuery>({
     query: STRATEGIES_QUERY,
     context: ctx,
   });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `GT-2` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
Hotfix patch for GAMMA, resource manager is taking too long to calculate capacity when there are more than 9 unique ID pools or random_signed_int pools. This performance issue will need deeper debugging and refactoring. Gamma need working RM to be able to test other products so that is why we are adding this hotfix. Capacity is removed only from pool table. 
