### PR TITLE
Fix executed workflow page

### DIFF
--- a/packages/frinx-workflow-ui/src/pages/executed-workflow-list/executed-workflow-list.tsx
+++ b/packages/frinx-workflow-ui/src/pages/executed-workflow-list/executed-workflow-list.tsx
@@ -137,6 +137,7 @@ const ExecutedWorkflowList = () => {
       },
       orderBy,
     },
+    requestPolicy: 'cache-and-network',
     context: ctx,
   });
 

--- a/packages/frinx-workflow-ui/src/pages/workflow-definitions/workflow-definitions-modals.tsx
+++ b/packages/frinx-workflow-ui/src/pages/workflow-definitions/workflow-definitions-modals.tsx
@@ -144,10 +144,12 @@ const WorkflowDefinitionsModals: VoidFunctionComponent<Props> = ({
       .then((res) => {
         if (!res.error) {
           addToastNotification({ content: 'We successfully executed workflow', type: 'success' });
+          return res.data?.executeWorkflowByName;
         }
         if (res.error) {
           addToastNotification({ content: res.error.message, type: 'error' });
         }
+        return null;
       })
       .catch(() => {
         addToastNotification({ content: 'We have a problem to execute selected workflow', type: 'error' });


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-580` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
- use cache-network request policy to update when new workflow was executed
- add return value to execute workflow modal in workflow definition list to allow user to directly redirect to executed workflow detail page
