### PR TITLE
move inventory queries to new proxy server

### DIFF
--- a/packages/frinx-inventory-client/codegen.yml
+++ b/packages/frinx-inventory-client/codegen.yml
@@ -1,5 +1,5 @@
 schema:
-  - https://localhost:8001/graphql
+  - http://127.0.0.1:5555/graphql
 documents:
   - './src/**/*.tsx'
   - './src/**/*.ts'

--- a/packages/frinx-inventory-client/src/__generated__/graphql.ts
+++ b/packages/frinx-inventory-client/src/__generated__/graphql.ts
@@ -12,55 +12,29 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  Record: { input: any; output: any; }
+  BigInt: { input: any; output: any; }
+  File: { input: any; output: any; }
+  JSON: { input: any; output: any; }
+  ObjMap: { input: any; output: any; }
   Upload: { input: any; output: any; }
+  Void: { input: any; output: any; }
 };
 
-export type ActionCompleteTask = {
-  __typename?: 'ActionCompleteTask';
-  output: Maybe<Scalars['String']['output']>;
-  taskId: Maybe<Scalars['String']['output']>;
-  taskRefName: Maybe<Scalars['String']['output']>;
-  workflowId: Maybe<Scalars['String']['output']>;
+export type Action = {
+  __typename?: 'Action';
+  action: Maybe<MutationInput_UpdateEventHandler_Input_Actions_Items_Action>;
+  complete_task: Maybe<TaskDetails>;
+  expandInlineJSON: Maybe<Scalars['Boolean']['output']>;
+  fail_task: Maybe<TaskDetails>;
+  start_workflow: Maybe<StartWorkflow>;
 };
 
-export type ActionCompleteTaskInput = {
-  output?: InputMaybe<Scalars['String']['input']>;
-  taskId?: InputMaybe<Scalars['String']['input']>;
-  taskRefName?: InputMaybe<Scalars['String']['input']>;
-  workflowId?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type ActionFailTask = {
-  __typename?: 'ActionFailTask';
-  output: Maybe<Scalars['String']['output']>;
-  taskId: Maybe<Scalars['String']['output']>;
-  taskRefName: Maybe<Scalars['String']['output']>;
-  workflowId: Maybe<Scalars['String']['output']>;
-};
-
-export type ActionFailTaskInput = {
-  output?: InputMaybe<Scalars['String']['input']>;
-  taskId?: InputMaybe<Scalars['String']['input']>;
-  taskRefName?: InputMaybe<Scalars['String']['input']>;
-  workflowId?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type ActionStartWorkflow = {
-  __typename?: 'ActionStartWorkflow';
-  correlationId: Maybe<Scalars['String']['output']>;
-  input: Maybe<Scalars['String']['output']>;
-  name: Maybe<Scalars['String']['output']>;
-  taskToDomain: Maybe<Scalars['String']['output']>;
-  version: Maybe<Scalars['Int']['output']>;
-};
-
-export type ActionStartWorkflowInput = {
-  correlationId?: InputMaybe<Scalars['String']['input']>;
-  input?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  taskToDomain?: InputMaybe<Scalars['String']['input']>;
-  version?: InputMaybe<Scalars['Int']['input']>;
+export type Action_Input = {
+  action?: InputMaybe<MutationInput_UpdateEventHandler_Input_Actions_Items_Action>;
+  complete_task?: InputMaybe<TaskDetails_Input>;
+  expandInlineJSON?: InputMaybe<Scalars['Boolean']['input']>;
+  fail_task?: InputMaybe<TaskDetails_Input>;
+  start_workflow?: InputMaybe<StartWorkflow_Input>;
 };
 
 export type AddBlueprintInput = {
@@ -175,14 +149,10 @@ export type BulkInstallDevicesInput = {
   deviceIds: Array<Scalars['String']['input']>;
 };
 
-export type BulkOperationInput = {
-  executedWorkflowIds: Array<Scalars['String']['input']>;
-};
-
-export type BulkOperationResponse = {
-  __typename?: 'BulkOperationResponse';
-  bulkErrorResults: Maybe<Scalars['String']['output']>;
-  bulkSuccessfulResults: Maybe<Array<Scalars['String']['output']>>;
+export type BulkResponse = {
+  __typename?: 'BulkResponse';
+  bulkErrorResults: Maybe<Scalars['JSON']['output']>;
+  bulkSuccessfulResults: Maybe<Array<Maybe<Scalars['String']['output']>>>;
 };
 
 export type BulkUninstallDevicePayload = {
@@ -265,17 +235,6 @@ export type CountryEdge = {
   node: Country;
 };
 
-export type CreateEventHandlerInput = {
-  actions: Array<EventHandlerActionInput>;
-  condition?: InputMaybe<Scalars['String']['input']>;
-  evaluatorType?: InputMaybe<Scalars['String']['input']>;
-  /** The event is immutable and cannot be changed. */
-  event: Scalars['String']['input'];
-  isActive?: InputMaybe<Scalars['Boolean']['input']>;
-  /** The name is immutable and cannot be changed. Also it must be unique. */
-  name: Scalars['String']['input'];
-};
-
 export type CreateLabelInput = {
   name: Scalars['String']['input'];
 };
@@ -285,56 +244,9 @@ export type CreateLabelPayload = {
   label: Maybe<Label>;
 };
 
-export type CreateScheduleInput = {
-  cronString: Scalars['String']['input'];
-  isEnabled?: InputMaybe<Scalars['Boolean']['input']>;
-  name: Scalars['String']['input'];
-  parallelRuns?: InputMaybe<Scalars['Boolean']['input']>;
-  performFromDate?: InputMaybe<Scalars['String']['input']>;
-  performTillDate?: InputMaybe<Scalars['String']['input']>;
-  workflowContext?: InputMaybe<Scalars['String']['input']>;
-  workflowName: Scalars['String']['input'];
-  workflowVersion: Scalars['String']['input'];
-};
-
-export type CreateTaskDefinitionInput = {
-  accessPolicy?: InputMaybe<Scalars['String']['input']>;
-  backoffScaleFactor?: InputMaybe<Scalars['Int']['input']>;
-  concurrentExecLimit?: InputMaybe<Scalars['Int']['input']>;
-  createdBy?: InputMaybe<Scalars['String']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  executionNameSpace?: InputMaybe<Scalars['String']['input']>;
-  inputKeys?: InputMaybe<Array<Scalars['String']['input']>>;
-  inputTemplate?: InputMaybe<Scalars['String']['input']>;
-  isolationGroupId?: InputMaybe<Scalars['String']['input']>;
-  name: Scalars['String']['input'];
-  outputKeys?: InputMaybe<Array<Scalars['String']['input']>>;
-  ownerApp?: InputMaybe<Scalars['String']['input']>;
-  ownerEmail?: InputMaybe<Scalars['String']['input']>;
-  pollTimeoutSeconds?: InputMaybe<Scalars['Int']['input']>;
-  rateLimitFrequencyInSeconds?: InputMaybe<Scalars['Int']['input']>;
-  rateLimitPerFrequency?: InputMaybe<Scalars['Int']['input']>;
-  responseTimeoutSeconds?: InputMaybe<Scalars['Int']['input']>;
-  retryCount?: InputMaybe<Scalars['Int']['input']>;
-  retryDelaySeconds?: InputMaybe<Scalars['Int']['input']>;
-  retryLogic?: InputMaybe<RetryLogic>;
-  timeoutPolicy?: InputMaybe<TaskTimeoutPolicy>;
-  timeoutSeconds: Scalars['Int']['input'];
-  updatedBy?: InputMaybe<Scalars['String']['input']>;
-};
-
 export type CreateTransactionPayload = {
   __typename?: 'CreateTransactionPayload';
   transactionId: Maybe<Scalars['String']['output']>;
-};
-
-export type CreateWorkflowInput = {
-  workflow: WorkflowInput;
-};
-
-export type CreateWorkflowPayload = {
-  __typename?: 'CreateWorkflowPayload';
-  workflow: Workflow;
 };
 
 export type DataStore = {
@@ -368,16 +280,6 @@ export type DeleteSnapshotInput = {
 export type DeleteSnapshotPayload = {
   __typename?: 'DeleteSnapshotPayload';
   snapshot: Maybe<Snapshot>;
-};
-
-export type DeleteWorkflowInput = {
-  name: Scalars['String']['input'];
-  version: Scalars['Int']['input'];
-};
-
-export type DeleteWorkflowPayload = {
-  __typename?: 'DeleteWorkflowPayload';
-  workflow: Workflow;
 };
 
 export type Device = Node & {
@@ -454,199 +356,29 @@ export type EdgeSourceTarget = {
   nodeId: Scalars['String']['output'];
 };
 
-export type EditWorkflowScheduleInput = {
-  cronString?: InputMaybe<Scalars['String']['input']>;
-  isEnabled?: InputMaybe<Scalars['Boolean']['input']>;
-  parallelRuns?: InputMaybe<Scalars['Boolean']['input']>;
-  performFromDate?: InputMaybe<Scalars['String']['input']>;
-  performTillDate?: InputMaybe<Scalars['String']['input']>;
-  workflowContext?: InputMaybe<Scalars['String']['input']>;
-  workflowName?: InputMaybe<Scalars['String']['input']>;
-  workflowVersion?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type EventHandler = Node & {
+export type EventHandler = {
   __typename?: 'EventHandler';
-  actions: Array<EventHandlerAction>;
+  actions: Array<Maybe<Action>>;
+  active: Maybe<Scalars['Boolean']['output']>;
   condition: Maybe<Scalars['String']['output']>;
   evaluatorType: Maybe<Scalars['String']['output']>;
-  /** The event is immutable and cannot be changed. */
   event: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  isActive: Maybe<Scalars['Boolean']['output']>;
-  /** The name is immutable and cannot be changed. Also it must be unique. */
   name: Scalars['String']['output'];
 };
 
-export type EventHandlerAction = {
-  __typename?: 'EventHandlerAction';
-  action: Maybe<EventHandlerActionEnum>;
-  completeTask: Maybe<ActionCompleteTask>;
-  expandInlineJSON: Maybe<Scalars['Boolean']['output']>;
-  failTask: Maybe<ActionFailTask>;
-  startWorkflow: Maybe<ActionStartWorkflow>;
-};
-
-export type EventHandlerActionEnum =
-  | 'complete_task'
-  | 'fail_task'
-  | 'start_workflow';
-
-export type EventHandlerActionInput = {
-  action?: InputMaybe<EventHandlerActionEnum>;
-  completeTask?: InputMaybe<ActionCompleteTaskInput>;
-  expandInlineJSON?: InputMaybe<Scalars['Boolean']['input']>;
-  failTask?: InputMaybe<ActionFailTaskInput>;
-  startWorkflow?: InputMaybe<ActionStartWorkflowInput>;
-};
-
-export type EventHandlerConnection = {
-  __typename?: 'EventHandlerConnection';
-  edges: Maybe<Array<EventHandlerEdge>>;
-  pageInfo: PageInfo;
-};
-
-export type EventHandlerEdge = {
-  __typename?: 'EventHandlerEdge';
-  cursor: Scalars['String']['output'];
-  node: EventHandler;
-};
-
-export type EventHandlersOrderByInput = {
-  direction: SortDirection;
-  sortKey: SortEventHandlersBy;
-};
-
-export type ExecuteNewWorkflowInput = {
-  correlationId?: InputMaybe<Scalars['String']['input']>;
-  externalInputPayloadStoragePath?: InputMaybe<Scalars['String']['input']>;
-  input?: InputMaybe<Scalars['String']['input']>;
+export type EventHandler_Input = {
+  actions: Array<InputMaybe<Action_Input>>;
+  active?: InputMaybe<Scalars['Boolean']['input']>;
+  condition?: InputMaybe<Scalars['String']['input']>;
+  evaluatorType?: InputMaybe<Scalars['String']['input']>;
+  event: Scalars['String']['input'];
   name: Scalars['String']['input'];
-  priority?: InputMaybe<Scalars['Int']['input']>;
-  taskToDomain?: InputMaybe<Scalars['String']['input']>;
-  version?: InputMaybe<Scalars['Int']['input']>;
 };
 
-export type ExecuteWorkflowByName = {
-  correlationId?: InputMaybe<Scalars['String']['input']>;
-  /** JSON string of input parameters */
-  inputParameters: Scalars['String']['input'];
-  priority?: InputMaybe<Scalars['Int']['input']>;
-  workflowName: Scalars['String']['input'];
-  workflowVersion?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type ExecutedWorkflow = Node & {
-  __typename?: 'ExecutedWorkflow';
-  correlationId: Maybe<Scalars['String']['output']>;
-  createdAt: Maybe<Scalars['String']['output']>;
-  createdBy: Maybe<Scalars['String']['output']>;
-  endTime: Maybe<Scalars['String']['output']>;
-  failedReferenceTaskNames: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  id: Scalars['ID']['output'];
-  input: Maybe<Scalars['String']['output']>;
-  lastRetriedTime: Maybe<Scalars['String']['output']>;
-  output: Maybe<Scalars['String']['output']>;
-  ownerApp: Maybe<Scalars['String']['output']>;
-  parentWorkflowId: Maybe<Scalars['String']['output']>;
-  reasonForIncompletion: Maybe<Scalars['String']['output']>;
-  startTime: Maybe<Scalars['String']['output']>;
-  status: Maybe<ExecutedWorkflowStatus>;
-  tasks: Maybe<Array<ExecutedWorkflowTask>>;
-  updatedAt: Maybe<Scalars['String']['output']>;
-  updatedBy: Maybe<Scalars['String']['output']>;
-  variables: Maybe<Scalars['String']['output']>;
-  workflowDefinition: Maybe<Workflow>;
-  workflowId: Scalars['String']['output'];
-  workflowName: Maybe<Scalars['String']['output']>;
-  workflowVersion: Maybe<Scalars['Int']['output']>;
-};
-
-export type ExecutedWorkflowConnection = {
-  __typename?: 'ExecutedWorkflowConnection';
-  edges: Array<ExecutedWorkflowEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
-
-export type ExecutedWorkflowEdge = {
-  __typename?: 'ExecutedWorkflowEdge';
-  cursor: Scalars['String']['output'];
-  node: ExecutedWorkflow;
-};
-
-export type ExecutedWorkflowFilterInput = {
-  startTime?: InputMaybe<ExecutedWorkflowStartTimeRange>;
-  status?: InputMaybe<Array<ExecutedWorkflowStatus>>;
-  workflowId?: InputMaybe<Array<Scalars['String']['input']>>;
-  workflowType?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
-export type ExecutedWorkflowSearchInput = {
-  isRootWorkflow?: InputMaybe<Scalars['Boolean']['input']>;
-  query?: InputMaybe<ExecutedWorkflowFilterInput>;
-};
-
-export type ExecutedWorkflowStartTimeRange = {
-  from: Scalars['String']['input'];
-  to?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type ExecutedWorkflowStatus =
-  | 'COMPLETED'
-  | 'FAILED'
-  | 'PAUSED'
-  | 'RUNNING'
-  | 'TERMINATED'
-  | 'TIMED_OUT';
-
-export type ExecutedWorkflowTask = Node & {
-  __typename?: 'ExecutedWorkflowTask';
-  callbackAfterSeconds: Maybe<Scalars['Int']['output']>;
-  endTime: Maybe<Scalars['String']['output']>;
-  executed: Maybe<Scalars['Boolean']['output']>;
-  externalInputPayloadStoragePath: Maybe<Scalars['String']['output']>;
-  externalOutputPayloadStoragePath: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  inputData: Maybe<Scalars['String']['output']>;
-  outputData: Maybe<Scalars['String']['output']>;
-  pollCount: Maybe<Scalars['Int']['output']>;
-  reasonForIncompletion: Maybe<Scalars['String']['output']>;
-  referenceTaskName: Maybe<Scalars['String']['output']>;
-  retried: Maybe<Scalars['Boolean']['output']>;
-  retryCount: Maybe<Scalars['Int']['output']>;
-  scheduledTime: Maybe<Scalars['String']['output']>;
-  seq: Maybe<Scalars['Int']['output']>;
-  startTime: Maybe<Scalars['String']['output']>;
-  status: Maybe<ExecutedWorkflowTaskStatus>;
-  subWorkflowId: Maybe<Scalars['String']['output']>;
-  taskDefName: Maybe<Scalars['String']['output']>;
-  taskDefinition: Maybe<Scalars['String']['output']>;
-  taskId: Maybe<Scalars['String']['output']>;
-  taskType: Maybe<Scalars['String']['output']>;
-  updateTime: Maybe<Scalars['String']['output']>;
-  workflowType: Maybe<Scalars['String']['output']>;
-};
-
-export type ExecutedWorkflowTaskStatus =
-  | 'CANCELED'
-  | 'COMPLETED'
-  | 'COMPLETED_WITH_ERROR'
-  | 'FAILED'
-  | 'FAILED_WITH_TERMINAL_ERROR'
-  | 'IN_PROGRESS'
-  | 'SCHEDULED'
-  | 'SKIPPED'
-  | 'TIMED_OUT';
-
-export type ExecutedWorkflowsOrderByInput = {
-  direction: SortExecutedWorkflowsDirection;
-  sortKey: SortExecutedWorkflowsBy;
-};
-
-export type ExternaStorage = {
-  __typename?: 'ExternaStorage';
-  data: Scalars['String']['output'];
+export type ExternalStorageLocation = {
+  __typename?: 'ExternalStorageLocation';
+  path: Maybe<Scalars['String']['output']>;
+  uri: Maybe<Scalars['String']['output']>;
 };
 
 export type FilterDevicesInput = {
@@ -654,49 +386,16 @@ export type FilterDevicesInput = {
   labels?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
-export type FilterEventHandlerInput = {
-  evaluatorType?: InputMaybe<Scalars['String']['input']>;
-  event?: InputMaybe<Scalars['String']['input']>;
-  isActive?: InputMaybe<Scalars['Boolean']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-};
-
 export type FilterLabelsInput = {
   name: Scalars['String']['input'];
-};
-
-export type FilterPollDataInput = {
-  afterDate?: InputMaybe<Scalars['String']['input']>;
-  beforeDate?: InputMaybe<Scalars['String']['input']>;
-  domain?: InputMaybe<Scalars['String']['input']>;
-  queueName?: InputMaybe<Scalars['String']['input']>;
-  workerId?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type FilterPoolsInput = {
-  poolName?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type FilterTaskDefinitionsInput = {
-  keyword?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type FilterTopologyInput = {
   labels?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
-export type FilterWorkflowsInput = {
-  keyword?: InputMaybe<Scalars['String']['input']>;
-  labels?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
 export type FilterZonesInput = {
   name: Scalars['String']['input'];
-};
-
-export type FreeResourceInput = {
-  poolId: Scalars['String']['input'];
-  resource: Scalars['Record']['input'];
 };
 
 export type GraphEdge = {
@@ -757,6 +456,31 @@ export type GraphVersionNode = BaseGraphNode & {
   softwareVersion: Maybe<Scalars['String']['output']>;
 };
 
+export type HttpMethod =
+  | 'CONNECT'
+  | 'DELETE'
+  | 'GET'
+  | 'HEAD'
+  | 'OPTIONS'
+  | 'PATCH'
+  | 'POST'
+  | 'PUT'
+  | 'TRACE';
+
+export type Health = {
+  __typename?: 'Health';
+  details: Maybe<Scalars['JSON']['output']>;
+  errorMessage: Maybe<Scalars['String']['output']>;
+  healthy: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type HealthCheckStatus = {
+  __typename?: 'HealthCheckStatus';
+  healthResults: Maybe<Array<Maybe<Health>>>;
+  healthy: Maybe<Scalars['Boolean']['output']>;
+  suppressedHealthResults: Maybe<Array<Maybe<Health>>>;
+};
+
 export type InstallDevicePayload = {
   __typename?: 'InstallDevicePayload';
   device: Device;
@@ -812,330 +536,8 @@ export type LocationEdge = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  addBlueprint: AddBlueprintPayload;
-  addDevice: AddDevicePayload;
-  addLocation: AddLocationPayload;
-  addSnapshot: Maybe<AddSnapshotPayload>;
-  addZone: AddZonePayload;
-  applySnapshot: ApplySnapshotPayload;
-  bulkInstallDevices: BulkInstallDevicePayload;
-  bulkPauseWorkflow: Maybe<BulkOperationResponse>;
-  bulkRestartWorkflow: Maybe<BulkOperationResponse>;
-  bulkResumeWorkflow: Maybe<BulkOperationResponse>;
-  bulkRetryWorkflow: Maybe<BulkOperationResponse>;
-  bulkTerminateWorkflow: Maybe<BulkOperationResponse>;
-  bulkUninstallDevices: BulkUninstallDevicePayload;
-  closeTransaction: CloseTransactionPayload;
-  commitConfig: CommitConfigPayload;
-  createEventHandler: Maybe<EventHandler>;
-  createLabel: CreateLabelPayload;
-  createTaskDefinition: Maybe<TaskDefinition>;
-  createTransaction: CreateTransactionPayload;
-  createWorkflow: CreateWorkflowPayload;
-  deleteBlueprint: DeleteBlueprintPayload;
-  deleteDevice: DeleteDevicePayload;
-  deleteEventHandler: Maybe<IsOkResponse>;
-  deleteLabel: DeleteLabelPayload;
-  deleteSchedule: Maybe<IsOkResponse>;
-  deleteSnapshot: Maybe<DeleteSnapshotPayload>;
-  deleteTask: Maybe<IsOkResponse>;
-  deleteWorkflow: DeleteWorkflowPayload;
-  editWorkflowSchedule: Maybe<Schedule>;
-  executeNewWorkflow: Maybe<Scalars['String']['output']>;
-  executeWorkflowByName: Maybe<Scalars['String']['output']>;
-  freeResource: Maybe<Scalars['String']['output']>;
-  importCSV: Maybe<CsvImport>;
-  installDevice: InstallDevicePayload;
-  pauseWorkflow: Maybe<IsOkResponse>;
-  removeWorkflow: Maybe<IsOkResponse>;
-  resetConfig: ResetConfigPayload;
-  restartWorkflow: Maybe<IsOkResponse>;
-  resumeWorkflow: Maybe<IsOkResponse>;
-  retryWorkflow: Maybe<IsOkResponse>;
-  revertChanges: RevertChangesPayload;
-  scheduleWorkflow: Maybe<Schedule>;
-  syncFromNetwork: SyncFromNetworkPayload;
-  terminateWorkflow: Maybe<IsOkResponse>;
-  uninstallDevice: UninstallDevicePayload;
-  updateBlueprint: UpdateBlueprintPayload;
-  updateDataStore: UpdateDataStorePayload;
-  updateDevice: UpdateDevicePayload;
-  updateEventHandler: Maybe<EventHandler>;
-  updateGraphNodeCoordinates: UpdateGraphNodeCoordinatesPayload;
-  updateWorkflow: UpdateWorkflowPayload;
-};
-
-
-export type MutationAddBlueprintArgs = {
-  input: AddBlueprintInput;
-};
-
-
-export type MutationAddDeviceArgs = {
-  input: AddDeviceInput;
-};
-
-
-export type MutationAddLocationArgs = {
-  input: AddLocationInput;
-};
-
-
-export type MutationAddSnapshotArgs = {
-  input: AddSnapshotInput;
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationAddZoneArgs = {
-  input: AddZoneInput;
-};
-
-
-export type MutationApplySnapshotArgs = {
-  input: ApplySnapshotInput;
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationBulkInstallDevicesArgs = {
-  input: BulkInstallDevicesInput;
-};
-
-
-export type MutationBulkPauseWorkflowArgs = {
-  input: BulkOperationInput;
-};
-
-
-export type MutationBulkRestartWorkflowArgs = {
-  input: BulkOperationInput;
-};
-
-
-export type MutationBulkResumeWorkflowArgs = {
-  input: BulkOperationInput;
-};
-
-
-export type MutationBulkRetryWorkflowArgs = {
-  input: BulkOperationInput;
-};
-
-
-export type MutationBulkTerminateWorkflowArgs = {
-  input: BulkOperationInput;
-};
-
-
-export type MutationBulkUninstallDevicesArgs = {
-  input: BulkUninstallDevicesInput;
-};
-
-
-export type MutationCloseTransactionArgs = {
-  deviceId: Scalars['String']['input'];
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationCommitConfigArgs = {
-  input: CommitConfigInput;
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationCreateEventHandlerArgs = {
-  input: CreateEventHandlerInput;
-};
-
-
-export type MutationCreateLabelArgs = {
-  input: CreateLabelInput;
-};
-
-
-export type MutationCreateTaskDefinitionArgs = {
-  input: CreateTaskDefinitionInput;
-};
-
-
-export type MutationCreateTransactionArgs = {
-  deviceId: Scalars['String']['input'];
-};
-
-
-export type MutationCreateWorkflowArgs = {
-  input: CreateWorkflowInput;
-};
-
-
-export type MutationDeleteBlueprintArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationDeleteDeviceArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationDeleteEventHandlerArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationDeleteLabelArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationDeleteScheduleArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationDeleteSnapshotArgs = {
-  input: DeleteSnapshotInput;
-};
-
-
-export type MutationDeleteTaskArgs = {
-  name: Scalars['String']['input'];
-};
-
-
-export type MutationDeleteWorkflowArgs = {
-  input: DeleteWorkflowInput;
-};
-
-
-export type MutationEditWorkflowScheduleArgs = {
-  id: Scalars['String']['input'];
-  input: EditWorkflowScheduleInput;
-};
-
-
-export type MutationExecuteNewWorkflowArgs = {
-  input: StartWorkflowRequestInput;
-};
-
-
-export type MutationExecuteWorkflowByNameArgs = {
-  input: ExecuteWorkflowByName;
-};
-
-
-export type MutationFreeResourceArgs = {
-  input: FreeResourceInput;
-};
-
-
-export type MutationImportCsvArgs = {
-  input: CsvImportInput;
-};
-
-
-export type MutationInstallDeviceArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationPauseWorkflowArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationRemoveWorkflowArgs = {
-  id: Scalars['String']['input'];
-  input?: InputMaybe<RemoveWorkflowInput>;
-};
-
-
-export type MutationResetConfigArgs = {
-  deviceId: Scalars['String']['input'];
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationRestartWorkflowArgs = {
-  id: Scalars['String']['input'];
-  input?: InputMaybe<RestartWorkflowInput>;
-};
-
-
-export type MutationResumeWorkflowArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationRetryWorkflowArgs = {
-  id: Scalars['String']['input'];
-  input?: InputMaybe<RetryWorkflowInput>;
-};
-
-
-export type MutationRevertChangesArgs = {
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationScheduleWorkflowArgs = {
-  input: CreateScheduleInput;
-};
-
-
-export type MutationSyncFromNetworkArgs = {
-  deviceId: Scalars['String']['input'];
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationTerminateWorkflowArgs = {
-  id: Scalars['String']['input'];
-  input?: InputMaybe<TerminateWorkflowInput>;
-};
-
-
-export type MutationUninstallDeviceArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type MutationUpdateBlueprintArgs = {
-  id: Scalars['String']['input'];
-  input: UpdateBlueprintInput;
-};
-
-
-export type MutationUpdateDataStoreArgs = {
-  deviceId: Scalars['String']['input'];
-  input: UpdateDataStoreInput;
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type MutationUpdateDeviceArgs = {
-  id: Scalars['String']['input'];
-  input: UpdateDeviceInput;
-};
-
-
-export type MutationUpdateEventHandlerArgs = {
-  event: Scalars['String']['input'];
-  input: UpdateEventHandlerInput;
-  name: Scalars['String']['input'];
-};
-
-
-export type MutationUpdateGraphNodeCoordinatesArgs = {
-  input: Array<GraphNodeCoordinatesInput>;
-};
-
-
-export type MutationUpdateWorkflowArgs = {
-  id: Scalars['String']['input'];
-  input: UpdateWorkflowInput;
+  conductor: ConductorMutation;
+  deviceInventory: DeviceInventoryMutation;
 };
 
 export type NetInterface = {
@@ -1183,17 +585,6 @@ export type Node = {
   id: Scalars['ID']['output'];
 };
 
-export type OutputParameter = {
-  __typename?: 'OutputParameter';
-  key: Scalars['String']['output'];
-  value: Scalars['String']['output'];
-};
-
-export type OutputParameterInput = {
-  key: Scalars['String']['input'];
-  value: Scalars['String']['input'];
-};
-
 export type PageInfo = {
   __typename?: 'PageInfo';
   endCursor: Maybe<Scalars['String']['output']>;
@@ -1202,286 +593,26 @@ export type PageInfo = {
   startCursor: Maybe<Scalars['String']['output']>;
 };
 
-export type PaginationArgs = {
-  size: Scalars['Int']['input'];
-  start: Scalars['Int']['input'];
-};
-
 export type PollData = {
   __typename?: 'PollData';
   domain: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  lastPollTime: Maybe<Scalars['String']['output']>;
+  lastPollTime: Maybe<Scalars['BigInt']['output']>;
   queueName: Maybe<Scalars['String']['output']>;
   workerId: Maybe<Scalars['String']['output']>;
 };
 
-export type PollDataConnection = {
-  __typename?: 'PollDataConnection';
-  edges: Maybe<Array<Maybe<PollDataEdge>>>;
-  pageInfo: Maybe<PageInfo>;
-  totalCount: Maybe<Scalars['Int']['output']>;
-};
-
-export type PollDataEdge = {
-  __typename?: 'PollDataEdge';
-  cursor: Maybe<Scalars['String']['output']>;
-  node: Maybe<PollData>;
-};
-
-export type PollsOrderByInput = {
-  direction: SortPollsDirection;
-  sortKey: SortPollsBy;
-};
-
-export type Pool = Node & {
-  __typename?: 'Pool';
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-  poolProperties: Scalars['Record']['output'];
-  poolType: PoolType;
-  resourceType: ResourceType;
-  tags: Array<Tag>;
-};
-
-export type PoolConnection = {
-  __typename?: 'PoolConnection';
-  edges: Array<PoolEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
-
-export type PoolEdge = {
-  __typename?: 'PoolEdge';
-  cursor: Scalars['String']['output'];
-  node: Pool;
-};
-
-export type PoolType =
-  | 'allocating'
-  | 'set'
-  | 'singleton';
-
 export type Query = {
   __typename?: 'Query';
-  blueprints: BlueprintConnection;
-  calculatedDiff: CalculatedDiffPayload;
-  countries: CountryConnection;
-  dataStore: Maybe<DataStore>;
-  devices: DeviceConnection;
-  eventHandler: Maybe<EventHandler>;
-  eventHandlers: Maybe<EventHandlerConnection>;
-  eventHandlersByEvent: Maybe<EventHandlerConnection>;
-  executedWorkflows: Maybe<ExecutedWorkflowConnection>;
-  externalStorage: Maybe<ExternaStorage>;
-  labels: LabelConnection;
-  locations: LocationConnection;
-  netTopology: Maybe<NetTopology>;
-  node: Maybe<Node>;
-  pollData: Maybe<PollDataConnection>;
-  pools: PoolConnection;
-  schedules: ScheduleConnection;
-  shortestPath: Array<NetRoutingPathNode>;
-  taskDefinitions: TaskDefinitionConnection;
-  topology: Maybe<Topology>;
-  topologyCommonNodes: Maybe<TopologyCommonNodes>;
-  topologyVersionData: TopologyVersionData;
-  topologyVersions: Maybe<Array<Scalars['String']['output']>>;
-  transactions: Array<Transaction>;
-  uniconfigShellSession: Maybe<Scalars['String']['output']>;
-  workflowInstanceDetail: Maybe<WorkflowInstanceDetail>;
-  workflowLabels: Array<Scalars['String']['output']>;
-  workflows: WorkflowConnection;
-  zones: ZonesConnection;
+  conductor: ConductorQuery;
+  deviceInventory: DeviceInventoryQuery;
 };
 
-
-export type QueryBlueprintsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryCalculatedDiffArgs = {
-  deviceId: Scalars['String']['input'];
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type QueryCountriesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryDataStoreArgs = {
-  deviceId: Scalars['String']['input'];
-  transactionId: Scalars['String']['input'];
-};
-
-
-export type QueryDevicesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterDevicesInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<DeviceOrderByInput>;
-};
-
-
-export type QueryEventHandlerArgs = {
-  event: Scalars['String']['input'];
-  name: Scalars['String']['input'];
-};
-
-
-export type QueryEventHandlersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterEventHandlerInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<EventHandlersOrderByInput>;
-};
-
-
-export type QueryEventHandlersByEventArgs = {
-  activeOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  event: Scalars['String']['input'];
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryExecutedWorkflowsArgs = {
-  orderBy?: InputMaybe<ExecutedWorkflowsOrderByInput>;
-  pagination?: InputMaybe<PaginationArgs>;
-  searchQuery?: InputMaybe<ExecutedWorkflowSearchInput>;
-};
-
-
-export type QueryExternalStorageArgs = {
-  path: Scalars['String']['input'];
-};
-
-
-export type QueryLabelsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterLabelsInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryLocationsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryNodeArgs = {
-  id: Scalars['ID']['input'];
-  version?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryPollDataArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterPollDataInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  orderBy: PollsOrderByInput;
-};
-
-
-export type QueryPoolsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterPoolsInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  resourceTypeId?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type QuerySchedulesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<ScheduleFilterInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-
-export type QueryShortestPathArgs = {
-  from: Scalars['String']['input'];
-  to: Scalars['String']['input'];
-};
-
-
-export type QueryTaskDefinitionsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterTaskDefinitionsInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<TasksOrderByInput>;
-};
-
-
-export type QueryTopologyArgs = {
-  filter?: InputMaybe<FilterTopologyInput>;
-};
-
-
-export type QueryTopologyCommonNodesArgs = {
-  nodes: Array<Scalars['String']['input']>;
-};
-
-
-export type QueryTopologyVersionDataArgs = {
-  version: Scalars['String']['input'];
-};
-
-
-export type QueryWorkflowInstanceDetailArgs = {
-  shouldIncludeTasks?: InputMaybe<Scalars['Boolean']['input']>;
-  workflowId: Scalars['String']['input'];
-};
-
-
-export type QueryWorkflowsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterWorkflowsInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  orderBy?: InputMaybe<WorkflowsOrderByInput>;
-};
-
-
-export type QueryZonesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<FilterZonesInput>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type RemoveWorkflowInput = {
-  /** Default value is true */
-  shouldArchiveWorkflow?: InputMaybe<Scalars['Boolean']['input']>;
+export type RerunWorkflowRequest_Input = {
+  correlationId?: InputMaybe<Scalars['String']['input']>;
+  reRunFromTaskId?: InputMaybe<Scalars['String']['input']>;
+  reRunFromWorkflowId?: InputMaybe<Scalars['String']['input']>;
+  taskInput?: InputMaybe<Scalars['JSON']['input']>;
+  workflowInput?: InputMaybe<Scalars['JSON']['input']>;
 };
 
 export type ResetConfigPayload = {
@@ -1489,77 +620,39 @@ export type ResetConfigPayload = {
   dataStore: DataStore;
 };
 
-export type ResourceType = {
-  __typename?: 'ResourceType';
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
-};
-
-export type ResourceTypeInput = {
-  resourceTypeId?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type RestartWorkflowInput = {
-  /** Default value is true */
-  shouldUseLatestDefinitions?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-export type RetryLogic =
-  | 'EXPONENTIAL_BACKOFF'
-  | 'FIXED'
-  | 'LINEAR_BACKOFF';
-
-export type RetryWorkflowInput = {
-  /** Default value is true */
-  shouldResumeSubworkflowTasks?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
 export type RevertChangesPayload = {
   __typename?: 'RevertChangesPayload';
   isOk: Scalars['Boolean']['output'];
 };
 
-export type Schedule = Node & {
-  __typename?: 'Schedule';
-  cronString: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  isEnabled: Scalars['Boolean']['output'];
-  name: Scalars['String']['output'];
-  parallelRuns: Scalars['Boolean']['output'];
-  performFromDate: Scalars['String']['output'];
-  performTillDate: Scalars['String']['output'];
-  status: ScheduleStatus;
-  workflowContext: Scalars['String']['output'];
-  workflowName: Scalars['String']['output'];
-  workflowVersion: Scalars['String']['output'];
+export type SearchResultTask = {
+  __typename?: 'SearchResultTask';
+  results: Maybe<Array<Maybe<Task>>>;
+  totalHits: Maybe<Scalars['BigInt']['output']>;
 };
 
-export type ScheduleConnection = {
-  __typename?: 'ScheduleConnection';
-  edges: Array<Maybe<ScheduleEdge>>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
+export type SearchResultTaskSummary = {
+  __typename?: 'SearchResultTaskSummary';
+  results: Maybe<Array<Maybe<TaskSummary>>>;
+  totalHits: Maybe<Scalars['BigInt']['output']>;
 };
 
-export type ScheduleEdge = {
-  __typename?: 'ScheduleEdge';
-  cursor: Scalars['String']['output'];
-  node: Schedule;
+export type SearchResultWorkflow = {
+  __typename?: 'SearchResultWorkflow';
+  results: Maybe<Array<Maybe<Workflow>>>;
+  totalHits: Maybe<Scalars['BigInt']['output']>;
 };
 
-export type ScheduleFilterInput = {
-  workflowName: Scalars['String']['input'];
-  workflowVersion: Scalars['String']['input'];
+export type SearchResultWorkflowSummary = {
+  __typename?: 'SearchResultWorkflowSummary';
+  results: Maybe<Array<Maybe<WorkflowSummary>>>;
+  totalHits: Maybe<Scalars['BigInt']['output']>;
 };
 
-export type ScheduleStatus =
-  | 'COMPLETED'
-  | 'FAILED'
-  | 'PAUSED'
-  | 'RUNNING'
-  | 'TERMINATED'
-  | 'TIMED_OUT'
-  | 'UNKNOWN';
+export type SkipTaskRequest_Input = {
+  taskInput?: InputMaybe<Scalars['JSON']['input']>;
+  taskOutput?: InputMaybe<Scalars['JSON']['input']>;
+};
 
 export type Snapshot = {
   __typename?: 'Snapshot';
@@ -1576,71 +669,52 @@ export type SortDirection =
   | 'ASC'
   | 'DESC';
 
-export type SortEventHandlersBy =
-  | 'evaluatorType'
-  | 'event'
-  | 'isActive'
-  | 'name';
-
-export type SortExecutedWorkflowsBy =
-  | 'endTime'
-  | 'startTime'
-  | 'status'
-  | 'workflowId'
-  | 'workflowName';
-
-export type SortExecutedWorkflowsDirection =
-  | 'asc'
-  | 'desc';
-
-export type SortPollsBy =
-  | 'lastPollTime'
-  | 'queueName'
-  | 'workerId';
-
-export type SortPollsDirection =
-  | 'asc'
-  | 'desc';
-
-export type SortTasksBy =
-  | 'name'
-  | 'responseTimeoutSeconds'
-  | 'retryCount'
-  | 'retryLogic'
-  | 'timeoutPolicy'
-  | 'timeoutSeconds';
-
-export type SortWorkflowsBy =
-  | 'name';
-
-export type StartWorkflowRequestInput = {
-  workflow: ExecuteNewWorkflowInput;
-  workflowDefinition?: InputMaybe<WorkflowDefinitionInput>;
+export type StartWorkflow = {
+  __typename?: 'StartWorkflow';
+  correlationId: Maybe<Scalars['String']['output']>;
+  input: Maybe<Scalars['JSON']['output']>;
+  name: Maybe<Scalars['String']['output']>;
+  taskToDomain: Maybe<Scalars['JSON']['output']>;
+  version: Maybe<Scalars['Int']['output']>;
 };
 
-export type SubWorkflow = {
-  __typename?: 'SubWorkflow';
-  executedWorkflowDetail: ExecutedWorkflow;
-  referenceTaskName: Scalars['String']['output'];
-  workflowDetail: Workflow;
+export type StartWorkflowRequest_Input = {
+  correlationId?: InputMaybe<Scalars['String']['input']>;
+  externalInputPayloadStoragePath?: InputMaybe<Scalars['String']['input']>;
+  input?: InputMaybe<Scalars['JSON']['input']>;
+  name: Scalars['String']['input'];
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  taskToDomain?: InputMaybe<Scalars['JSON']['input']>;
+  version?: InputMaybe<Scalars['Int']['input']>;
+  workflowDef?: InputMaybe<WorkflowDef_Input>;
+};
+
+export type StartWorkflow_Input = {
+  correlationId?: InputMaybe<Scalars['String']['input']>;
+  input?: InputMaybe<Scalars['JSON']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  taskToDomain?: InputMaybe<Scalars['JSON']['input']>;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type SubWorkflowParams = {
+  __typename?: 'SubWorkflowParams';
+  name: Scalars['String']['output'];
+  taskToDomain: Maybe<Scalars['JSON']['output']>;
+  version: Maybe<Scalars['Int']['output']>;
+  workflowDefinition: Maybe<WorkflowDef>;
+};
+
+export type SubWorkflowParams_Input = {
+  name: Scalars['String']['input'];
+  taskToDomain?: InputMaybe<Scalars['JSON']['input']>;
+  version?: InputMaybe<Scalars['Int']['input']>;
+  workflowDefinition?: InputMaybe<WorkflowDef_Input>;
 };
 
 export type Subscription = {
   __typename?: 'Subscription';
-  controlExecutedWorkflow: Maybe<ExecutedWorkflow>;
-  uniconfigShell: Maybe<Scalars['String']['output']>;
-};
-
-
-export type SubscriptionControlExecutedWorkflowArgs = {
-  id: Scalars['String']['input'];
-};
-
-
-export type SubscriptionUniconfigShellArgs = {
-  input?: InputMaybe<Scalars['String']['input']>;
-  sessionId: Scalars['String']['input'];
-  trigger?: InputMaybe<Scalars['Int']['input']>;
+  deviceInventory: DeviceInventorySubscription;
 };
 
 export type SyncFromNetworkPayload = {
@@ -1648,84 +722,173 @@ export type SyncFromNetworkPayload = {
   dataStore: Maybe<DataStore>;
 };
 
-export type Tag = {
-  __typename?: 'Tag';
-  id: Scalars['ID']['output'];
-  tag: Scalars['String']['output'];
+export type Task = {
+  __typename?: 'Task';
+  callbackAfterSeconds: Maybe<Scalars['BigInt']['output']>;
+  callbackFromWorker: Maybe<Scalars['Boolean']['output']>;
+  correlationId: Maybe<Scalars['String']['output']>;
+  domain: Maybe<Scalars['String']['output']>;
+  endTime: Maybe<Scalars['BigInt']['output']>;
+  executed: Maybe<Scalars['Boolean']['output']>;
+  executionNameSpace: Maybe<Scalars['String']['output']>;
+  externalInputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  externalOutputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  inputData: Maybe<Scalars['JSON']['output']>;
+  isolationGroupId: Maybe<Scalars['String']['output']>;
+  iteration: Maybe<Scalars['Int']['output']>;
+  loopOverTask: Maybe<Scalars['Boolean']['output']>;
+  outputData: Maybe<Scalars['JSON']['output']>;
+  pollCount: Maybe<Scalars['Int']['output']>;
+  queueWaitTime: Maybe<Scalars['BigInt']['output']>;
+  rateLimitFrequencyInSeconds: Maybe<Scalars['Int']['output']>;
+  rateLimitPerFrequency: Maybe<Scalars['Int']['output']>;
+  reasonForIncompletion: Maybe<Scalars['String']['output']>;
+  referenceTaskName: Maybe<Scalars['String']['output']>;
+  responseTimeoutSeconds: Maybe<Scalars['BigInt']['output']>;
+  retried: Maybe<Scalars['Boolean']['output']>;
+  retriedTaskId: Maybe<Scalars['String']['output']>;
+  retryCount: Maybe<Scalars['Int']['output']>;
+  scheduledTime: Maybe<Scalars['BigInt']['output']>;
+  seq: Maybe<Scalars['Int']['output']>;
+  startDelayInSeconds: Maybe<Scalars['Int']['output']>;
+  startTime: Maybe<Scalars['BigInt']['output']>;
+  status: Maybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_Status>;
+  subWorkflowId: Maybe<Scalars['String']['output']>;
+  subworkflowChanged: Maybe<Scalars['Boolean']['output']>;
+  taskDefName: Maybe<Scalars['String']['output']>;
+  taskDefinition: Maybe<TaskDef>;
+  taskId: Maybe<Scalars['String']['output']>;
+  taskType: Maybe<Scalars['String']['output']>;
+  updateTime: Maybe<Scalars['BigInt']['output']>;
+  workerId: Maybe<Scalars['String']['output']>;
+  workflowInstanceId: Maybe<Scalars['String']['output']>;
+  workflowPriority: Maybe<Scalars['Int']['output']>;
+  workflowTask: Maybe<WorkflowTask>;
+  workflowType: Maybe<Scalars['String']['output']>;
 };
 
-export type TaskDefinition = Node & {
-  __typename?: 'TaskDefinition';
+export type TaskDef = {
+  __typename?: 'TaskDef';
+  accessPolicy: Maybe<Scalars['JSON']['output']>;
+  backoffScaleFactor: Maybe<Scalars['Int']['output']>;
   concurrentExecLimit: Maybe<Scalars['Int']['output']>;
-  createdAt: Maybe<Scalars['String']['output']>;
+  createTime: Maybe<Scalars['BigInt']['output']>;
   createdBy: Maybe<Scalars['String']['output']>;
   description: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  inputKeys: Maybe<Array<Scalars['String']['output']>>;
-  inputTemplate: Maybe<Scalars['String']['output']>;
+  executionNameSpace: Maybe<Scalars['String']['output']>;
+  inputKeys: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  inputTemplate: Maybe<Scalars['JSON']['output']>;
+  isolationGroupId: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
-  outputKeys: Maybe<Array<Scalars['String']['output']>>;
+  outputKeys: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  ownerApp: Maybe<Scalars['String']['output']>;
   ownerEmail: Maybe<Scalars['String']['output']>;
   pollTimeoutSeconds: Maybe<Scalars['Int']['output']>;
   rateLimitFrequencyInSeconds: Maybe<Scalars['Int']['output']>;
   rateLimitPerFrequency: Maybe<Scalars['Int']['output']>;
-  responseTimeoutSeconds: Maybe<Scalars['Int']['output']>;
+  responseTimeoutSeconds: Maybe<Scalars['BigInt']['output']>;
   retryCount: Maybe<Scalars['Int']['output']>;
   retryDelaySeconds: Maybe<Scalars['Int']['output']>;
-  retryLogic: Maybe<RetryLogic>;
-  timeoutPolicy: Maybe<TaskTimeoutPolicy>;
-  timeoutSeconds: Scalars['Int']['output'];
-  updatedAt: Maybe<Scalars['String']['output']>;
+  retryLogic: Maybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_TaskDefinition_RetryLogic>;
+  timeoutPolicy: Maybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_TaskDefinition_TimeoutPolicy>;
+  timeoutSeconds: Scalars['BigInt']['output'];
+  updateTime: Maybe<Scalars['BigInt']['output']>;
   updatedBy: Maybe<Scalars['String']['output']>;
 };
 
-export type TaskDefinitionConnection = {
-  __typename?: 'TaskDefinitionConnection';
-  edges: Array<TaskDefinitionEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
-
-export type TaskDefinitionEdge = {
-  __typename?: 'TaskDefinitionEdge';
-  cursor: Scalars['String']['output'];
-  node: TaskDefinition;
-};
-
-export type TaskInput = {
-  asyncComplete?: InputMaybe<Scalars['Boolean']['input']>;
-  decisionCases?: InputMaybe<Scalars['String']['input']>;
-  defaultCase?: InputMaybe<Scalars['String']['input']>;
+export type TaskDef_Input = {
+  accessPolicy?: InputMaybe<Scalars['JSON']['input']>;
+  backoffScaleFactor?: InputMaybe<Scalars['Int']['input']>;
+  concurrentExecLimit?: InputMaybe<Scalars['Int']['input']>;
+  createTime?: InputMaybe<Scalars['BigInt']['input']>;
+  createdBy?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
-  inputParameters?: InputMaybe<Scalars['String']['input']>;
-  joinOn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  loopCondition?: InputMaybe<Scalars['String']['input']>;
+  executionNameSpace?: InputMaybe<Scalars['String']['input']>;
+  inputKeys?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  inputTemplate?: InputMaybe<Scalars['JSON']['input']>;
+  isolationGroupId?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
-  optional?: InputMaybe<Scalars['Boolean']['input']>;
+  outputKeys?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  ownerApp?: InputMaybe<Scalars['String']['input']>;
+  ownerEmail?: InputMaybe<Scalars['String']['input']>;
+  pollTimeoutSeconds?: InputMaybe<Scalars['Int']['input']>;
+  rateLimitFrequencyInSeconds?: InputMaybe<Scalars['Int']['input']>;
+  rateLimitPerFrequency?: InputMaybe<Scalars['Int']['input']>;
+  responseTimeoutSeconds?: InputMaybe<Scalars['BigInt']['input']>;
   retryCount?: InputMaybe<Scalars['Int']['input']>;
-  startDelay?: InputMaybe<Scalars['Int']['input']>;
-  taskReferenceName: Scalars['String']['input'];
-  type?: InputMaybe<Scalars['String']['input']>;
-  workflowTaskType?: InputMaybe<Array<InputMaybe<WorkflowTaskType>>>;
+  retryDelaySeconds?: InputMaybe<Scalars['Int']['input']>;
+  retryLogic?: InputMaybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_TaskDefinition_RetryLogic>;
+  timeoutPolicy?: InputMaybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_TaskDefinition_TimeoutPolicy>;
+  timeoutSeconds: Scalars['BigInt']['input'];
+  updateTime?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedBy?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type TaskTimeoutPolicy =
-  | 'ALERT_ONLY'
-  | 'RETRY'
-  | 'TIME_OUT_WF';
-
-export type TasksOrderByInput = {
-  direction: SortDirection;
-  sortKey: SortTasksBy;
+export type TaskDetails = {
+  __typename?: 'TaskDetails';
+  output: Maybe<Scalars['JSON']['output']>;
+  taskId: Maybe<Scalars['String']['output']>;
+  taskRefName: Maybe<Scalars['String']['output']>;
+  workflowId: Maybe<Scalars['String']['output']>;
 };
 
-export type TerminateWorkflowInput = {
-  reason?: InputMaybe<Scalars['String']['input']>;
+export type TaskDetails_Input = {
+  output?: InputMaybe<Scalars['JSON']['input']>;
+  taskId?: InputMaybe<Scalars['String']['input']>;
+  taskRefName?: InputMaybe<Scalars['String']['input']>;
+  workflowId?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type TimeoutPolicy =
-  | 'ALERT_ONLY'
-  | 'TIME_OUT_WF';
+export type TaskExecLog = {
+  __typename?: 'TaskExecLog';
+  createdTime: Maybe<Scalars['BigInt']['output']>;
+  log: Maybe<Scalars['String']['output']>;
+  taskId: Maybe<Scalars['String']['output']>;
+};
+
+export type TaskExecLog_Input = {
+  createdTime?: InputMaybe<Scalars['BigInt']['input']>;
+  log?: InputMaybe<Scalars['String']['input']>;
+  taskId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type TaskResult_Input = {
+  callbackAfterSeconds?: InputMaybe<Scalars['BigInt']['input']>;
+  extendLease?: InputMaybe<Scalars['Boolean']['input']>;
+  externalOutputPayloadStoragePath?: InputMaybe<Scalars['String']['input']>;
+  logs?: InputMaybe<Array<InputMaybe<TaskExecLog_Input>>>;
+  outputData?: InputMaybe<Scalars['JSON']['input']>;
+  reasonForIncompletion?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<MutationInput_UpdateTask_Input_Status>;
+  subWorkflowId?: InputMaybe<Scalars['String']['input']>;
+  taskId: Scalars['String']['input'];
+  workerId?: InputMaybe<Scalars['String']['input']>;
+  workflowInstanceId: Scalars['String']['input'];
+};
+
+export type TaskSummary = {
+  __typename?: 'TaskSummary';
+  correlationId: Maybe<Scalars['String']['output']>;
+  domain: Maybe<Scalars['String']['output']>;
+  endTime: Maybe<Scalars['String']['output']>;
+  executionTime: Maybe<Scalars['BigInt']['output']>;
+  externalInputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  externalOutputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  input: Maybe<Scalars['String']['output']>;
+  output: Maybe<Scalars['String']['output']>;
+  queueWaitTime: Maybe<Scalars['BigInt']['output']>;
+  reasonForIncompletion: Maybe<Scalars['String']['output']>;
+  scheduledTime: Maybe<Scalars['String']['output']>;
+  startTime: Maybe<Scalars['String']['output']>;
+  status: Maybe<Query_Search_1_Results_Items_Status>;
+  taskDefName: Maybe<Scalars['String']['output']>;
+  taskId: Maybe<Scalars['String']['output']>;
+  taskType: Maybe<Scalars['String']['output']>;
+  updateTime: Maybe<Scalars['String']['output']>;
+  workflowId: Maybe<Scalars['String']['output']>;
+  workflowPriority: Maybe<Scalars['Int']['output']>;
+  workflowType: Maybe<Scalars['String']['output']>;
+};
 
 export type Topology = {
   __typename?: 'Topology';
@@ -1815,142 +978,186 @@ export type UpdateDevicePayload = {
   device: Maybe<Device>;
 };
 
-export type UpdateEventHandlerInput = {
-  actions?: InputMaybe<Array<EventHandlerActionInput>>;
-  condition?: InputMaybe<Scalars['String']['input']>;
-  evaluatorType?: InputMaybe<Scalars['String']['input']>;
-  isActive?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
 export type UpdateGraphNodeCoordinatesPayload = {
   __typename?: 'UpdateGraphNodeCoordinatesPayload';
   deviceNames: Array<Scalars['String']['output']>;
 };
 
-export type UpdateWorkflowInput = {
-  workflow: WorkflowInput;
-};
-
-export type UpdateWorkflowPayload = {
-  __typename?: 'UpdateWorkflowPayload';
-  workflow: Workflow;
-};
-
-export type Workflow = Node & {
+export type Workflow = {
   __typename?: 'Workflow';
-  accessPolicy: Maybe<Scalars['Record']['output']>;
-  createdAt: Maybe<Scalars['String']['output']>;
+  correlationId: Maybe<Scalars['String']['output']>;
+  createTime: Maybe<Scalars['BigInt']['output']>;
+  createdBy: Maybe<Scalars['String']['output']>;
+  endTime: Maybe<Scalars['BigInt']['output']>;
+  event: Maybe<Scalars['String']['output']>;
+  externalInputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  externalOutputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  failedReferenceTaskNames: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  failedTaskNames: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  input: Maybe<Scalars['JSON']['output']>;
+  lastRetriedTime: Maybe<Scalars['BigInt']['output']>;
+  output: Maybe<Scalars['JSON']['output']>;
+  ownerApp: Maybe<Scalars['String']['output']>;
+  parentWorkflowId: Maybe<Scalars['String']['output']>;
+  parentWorkflowTaskId: Maybe<Scalars['String']['output']>;
+  priority: Maybe<Scalars['Int']['output']>;
+  reRunFromWorkflowId: Maybe<Scalars['String']['output']>;
+  reasonForIncompletion: Maybe<Scalars['String']['output']>;
+  startTime: Maybe<Scalars['BigInt']['output']>;
+  status: Maybe<Mutation_GetWorkflows_AdditionalProperties_Items_Status>;
+  taskToDomain: Maybe<Scalars['JSON']['output']>;
+  tasks: Maybe<Array<Maybe<Task>>>;
+  updateTime: Maybe<Scalars['BigInt']['output']>;
+  updatedBy: Maybe<Scalars['String']['output']>;
+  variables: Maybe<Scalars['JSON']['output']>;
+  workflowDefinition: Maybe<WorkflowDef>;
+  workflowId: Maybe<Scalars['String']['output']>;
+  workflowName: Maybe<Scalars['String']['output']>;
+  workflowVersion: Maybe<Scalars['Int']['output']>;
+};
+
+export type WorkflowDef = {
+  __typename?: 'WorkflowDef';
+  accessPolicy: Maybe<Scalars['JSON']['output']>;
+  createTime: Maybe<Scalars['BigInt']['output']>;
   createdBy: Maybe<Scalars['String']['output']>;
   description: Maybe<Scalars['String']['output']>;
   failureWorkflow: Maybe<Scalars['String']['output']>;
-  hasSchedule: Maybe<Scalars['Boolean']['output']>;
-  id: Scalars['ID']['output'];
-  inputParameters: Maybe<Array<Scalars['String']['output']>>;
-  inputTemplate: Maybe<Scalars['String']['output']>;
+  inputParameters: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  inputTemplate: Maybe<Scalars['JSON']['output']>;
   name: Scalars['String']['output'];
-  outputParameters: Maybe<Array<OutputParameter>>;
+  outputParameters: Maybe<Scalars['JSON']['output']>;
   ownerApp: Maybe<Scalars['String']['output']>;
   ownerEmail: Maybe<Scalars['String']['output']>;
   restartable: Maybe<Scalars['Boolean']['output']>;
   schemaVersion: Maybe<Scalars['Int']['output']>;
-  tasks: Maybe<Scalars['String']['output']>;
-  timeoutPolicy: Maybe<TimeoutPolicy>;
-  timeoutSeconds: Scalars['Int']['output'];
-  updatedAt: Maybe<Scalars['String']['output']>;
+  tasks: Array<Maybe<WorkflowTask>>;
+  timeoutPolicy: Maybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_SubWorkflowParam_WorkflowDefinition_TimeoutPolicy>;
+  timeoutSeconds: Scalars['BigInt']['output'];
+  updateTime: Maybe<Scalars['BigInt']['output']>;
   updatedBy: Maybe<Scalars['String']['output']>;
-  variables: Maybe<Scalars['Record']['output']>;
+  variables: Maybe<Scalars['JSON']['output']>;
   version: Maybe<Scalars['Int']['output']>;
   workflowStatusListenerEnabled: Maybe<Scalars['Boolean']['output']>;
 };
 
-export type WorkflowConnection = {
-  __typename?: 'WorkflowConnection';
-  edges: Array<WorkflowEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
-
-export type WorkflowDefinitionInput = {
-  createdBy?: InputMaybe<Scalars['String']['input']>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  inputParameters?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  inputTemplate?: InputMaybe<Scalars['String']['input']>;
-  name: Scalars['String']['input'];
-  outputParameters?: InputMaybe<Scalars['String']['input']>;
-  ownerApp?: InputMaybe<Scalars['String']['input']>;
-  ownerEmail?: InputMaybe<Scalars['String']['input']>;
-  restartable?: InputMaybe<Scalars['Boolean']['input']>;
-  schemaVersion?: InputMaybe<Scalars['Int']['input']>;
-  tasks: Array<TaskInput>;
-  timeoutPolicy?: InputMaybe<TimeoutPolicy>;
-  timeoutSeconds: Scalars['Int']['input'];
-  updatedBy?: InputMaybe<Scalars['String']['input']>;
-  variables?: InputMaybe<Scalars['String']['input']>;
-  version?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type WorkflowEdge = {
-  __typename?: 'WorkflowEdge';
-  cursor: Scalars['String']['output'];
-  node: Workflow;
-};
-
-export type WorkflowInput = {
-  accessPolicy?: InputMaybe<Scalars['Record']['input']>;
+export type WorkflowDef_Input = {
+  accessPolicy?: InputMaybe<Scalars['JSON']['input']>;
+  createTime?: InputMaybe<Scalars['BigInt']['input']>;
   createdBy?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   failureWorkflow?: InputMaybe<Scalars['String']['input']>;
-  inputParameters?: InputMaybe<Array<Scalars['String']['input']>>;
-  inputTemplate?: InputMaybe<Scalars['String']['input']>;
+  inputParameters?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  inputTemplate?: InputMaybe<Scalars['JSON']['input']>;
   name: Scalars['String']['input'];
-  outputParameters?: InputMaybe<Array<OutputParameterInput>>;
+  outputParameters?: InputMaybe<Scalars['JSON']['input']>;
   ownerApp?: InputMaybe<Scalars['String']['input']>;
   ownerEmail?: InputMaybe<Scalars['String']['input']>;
   restartable?: InputMaybe<Scalars['Boolean']['input']>;
   schemaVersion?: InputMaybe<Scalars['Int']['input']>;
-  tasks: Scalars['String']['input'];
-  timeoutPolicy?: InputMaybe<TimeoutPolicy>;
-  timeoutSeconds: Scalars['Int']['input'];
+  tasks: Array<InputMaybe<WorkflowTask_Input>>;
+  timeoutPolicy?: InputMaybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_SubWorkflowParam_WorkflowDefinition_TimeoutPolicy>;
+  timeoutSeconds: Scalars['BigInt']['input'];
+  updateTime?: InputMaybe<Scalars['BigInt']['input']>;
   updatedBy?: InputMaybe<Scalars['String']['input']>;
-  variables?: InputMaybe<Scalars['Record']['input']>;
+  variables?: InputMaybe<Scalars['JSON']['input']>;
   version?: InputMaybe<Scalars['Int']['input']>;
   workflowStatusListenerEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-export type WorkflowInstanceDetail = {
-  __typename?: 'WorkflowInstanceDetail';
-  meta: Maybe<Workflow>;
-  result: ExecutedWorkflow;
-  subworkflows: Maybe<Array<SubWorkflow>>;
+export type WorkflowSummary = {
+  __typename?: 'WorkflowSummary';
+  correlationId: Maybe<Scalars['String']['output']>;
+  endTime: Maybe<Scalars['String']['output']>;
+  event: Maybe<Scalars['String']['output']>;
+  executionTime: Maybe<Scalars['BigInt']['output']>;
+  externalInputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  externalOutputPayloadStoragePath: Maybe<Scalars['String']['output']>;
+  failedReferenceTaskNames: Maybe<Scalars['String']['output']>;
+  failedTaskNames: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  input: Maybe<Scalars['String']['output']>;
+  inputSize: Maybe<Scalars['BigInt']['output']>;
+  output: Maybe<Scalars['String']['output']>;
+  outputSize: Maybe<Scalars['BigInt']['output']>;
+  parentWorkflowId: Maybe<Scalars['String']['output']>;
+  priority: Maybe<Scalars['Int']['output']>;
+  reasonForIncompletion: Maybe<Scalars['String']['output']>;
+  startTime: Maybe<Scalars['String']['output']>;
+  status: Maybe<Query_Search_Results_Items_Status>;
+  updateTime: Maybe<Scalars['String']['output']>;
+  version: Maybe<Scalars['Int']['output']>;
+  workflowId: Maybe<Scalars['String']['output']>;
+  workflowType: Maybe<Scalars['String']['output']>;
 };
 
-export type WorkflowTaskType =
-  | 'DECISION'
-  | 'DO_WHILE'
-  | 'DYNAMIC'
-  | 'EVENT'
-  | 'EXCLUSIVE_JOIN'
-  | 'FORK_JOIN'
-  | 'FORK_JOIN_DYNAMIC'
-  | 'HTTP'
-  | 'HUMAN'
-  | 'INLINE'
-  | 'JOIN'
-  | 'JSON_JQ_TRANSFORM'
-  | 'KAFKA_PUBLISH'
-  | 'LAMBDA'
-  | 'SET_VARIABLE'
-  | 'SIMPLE'
-  | 'START_WORKFLOW'
-  | 'SUB_WORKFLOW'
-  | 'SWITCH'
-  | 'TERMINATE'
-  | 'USER_DEFINED'
-  | 'WAIT';
+export type WorkflowTask = {
+  __typename?: 'WorkflowTask';
+  asyncComplete: Maybe<Scalars['Boolean']['output']>;
+  /** @deprecated deprecated */
+  caseExpression: Maybe<Scalars['String']['output']>;
+  /** @deprecated deprecated */
+  caseValueParam: Maybe<Scalars['String']['output']>;
+  decisionCases: Maybe<Scalars['JSON']['output']>;
+  defaultCase: Maybe<Array<Maybe<WorkflowTask>>>;
+  defaultExclusiveJoinTask: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  description: Maybe<Scalars['String']['output']>;
+  /** @deprecated deprecated */
+  dynamicForkJoinTasksParam: Maybe<Scalars['String']['output']>;
+  dynamicForkTasksInputParamName: Maybe<Scalars['String']['output']>;
+  dynamicForkTasksParam: Maybe<Scalars['String']['output']>;
+  dynamicTaskNameParam: Maybe<Scalars['String']['output']>;
+  evaluatorType: Maybe<Scalars['String']['output']>;
+  expression: Maybe<Scalars['String']['output']>;
+  forkTasks: Maybe<Array<Maybe<Array<Maybe<WorkflowTask>>>>>;
+  inputParameters: Maybe<Scalars['JSON']['output']>;
+  joinOn: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  loopCondition: Maybe<Scalars['String']['output']>;
+  loopOver: Maybe<Array<Maybe<WorkflowTask>>>;
+  name: Scalars['String']['output'];
+  optional: Maybe<Scalars['Boolean']['output']>;
+  rateLimited: Maybe<Scalars['Boolean']['output']>;
+  retryCount: Maybe<Scalars['Int']['output']>;
+  scriptExpression: Maybe<Scalars['String']['output']>;
+  sink: Maybe<Scalars['String']['output']>;
+  startDelay: Maybe<Scalars['Int']['output']>;
+  subWorkflowParam: Maybe<SubWorkflowParams>;
+  taskDefinition: Maybe<TaskDef>;
+  taskReferenceName: Scalars['String']['output'];
+  type: Maybe<Scalars['String']['output']>;
+  workflowTaskType: Maybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_WorkflowTaskType>;
+};
 
-export type WorkflowsOrderByInput = {
-  direction: SortDirection;
-  sortKey: SortWorkflowsBy;
+export type WorkflowTask_Input = {
+  asyncComplete?: InputMaybe<Scalars['Boolean']['input']>;
+  caseExpression?: InputMaybe<Scalars['String']['input']>;
+  caseValueParam?: InputMaybe<Scalars['String']['input']>;
+  decisionCases?: InputMaybe<Scalars['JSON']['input']>;
+  defaultCase?: InputMaybe<Array<InputMaybe<WorkflowTask_Input>>>;
+  defaultExclusiveJoinTask?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  dynamicForkJoinTasksParam?: InputMaybe<Scalars['String']['input']>;
+  dynamicForkTasksInputParamName?: InputMaybe<Scalars['String']['input']>;
+  dynamicForkTasksParam?: InputMaybe<Scalars['String']['input']>;
+  dynamicTaskNameParam?: InputMaybe<Scalars['String']['input']>;
+  evaluatorType?: InputMaybe<Scalars['String']['input']>;
+  expression?: InputMaybe<Scalars['String']['input']>;
+  forkTasks?: InputMaybe<Array<InputMaybe<Array<InputMaybe<WorkflowTask_Input>>>>>;
+  inputParameters?: InputMaybe<Scalars['JSON']['input']>;
+  joinOn?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  loopCondition?: InputMaybe<Scalars['String']['input']>;
+  loopOver?: InputMaybe<Array<InputMaybe<WorkflowTask_Input>>>;
+  name: Scalars['String']['input'];
+  optional?: InputMaybe<Scalars['Boolean']['input']>;
+  rateLimited?: InputMaybe<Scalars['Boolean']['input']>;
+  retryCount?: InputMaybe<Scalars['Int']['input']>;
+  scriptExpression?: InputMaybe<Scalars['String']['input']>;
+  sink?: InputMaybe<Scalars['String']['input']>;
+  startDelay?: InputMaybe<Scalars['Int']['input']>;
+  subWorkflowParam?: InputMaybe<SubWorkflowParams_Input>;
+  taskDefinition?: InputMaybe<TaskDef_Input>;
+  taskReferenceName: Scalars['String']['input'];
+  type?: InputMaybe<Scalars['String']['input']>;
+  workflowTaskType?: InputMaybe<Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_WorkflowTaskType>;
 };
 
 export type Zone = Node & {
@@ -1974,72 +1181,1006 @@ export type ZonesConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+export type ConductorMutation = {
+  __typename?: 'conductorMutation';
+  /** Add a new event handler. */
+  addEventHandler: Maybe<Scalars['JSON']['output']>;
+  /** Create a new workflow definition */
+  create: Maybe<Scalars['JSON']['output']>;
+  /** Starts the decision task for a workflow */
+  decide: Maybe<Scalars['JSON']['output']>;
+  /** Removes the workflow from the system */
+  delete: Maybe<Scalars['JSON']['output']>;
+  /** Lists workflows for the given correlation id list */
+  getWorkflows: Maybe<Scalars['JSON']['output']>;
+  /** Log Task Execution Details */
+  log: Maybe<Scalars['JSON']['output']>;
+  /** Pauses the workflow */
+  pauseWorkflow: Maybe<Scalars['JSON']['output']>;
+  /** Pause the list of workflows */
+  pauseWorkflow_1: Maybe<BulkResponse>;
+  /** Update an existing task */
+  registerTaskDef: Maybe<Scalars['JSON']['output']>;
+  /** Create new task definition(s) */
+  registerTaskDef_1: Maybe<Scalars['JSON']['output']>;
+  /** Remove an event handler */
+  removeEventHandlerStatus: Maybe<Scalars['JSON']['output']>;
+  /** Requeue pending tasks */
+  requeuePendingTask: Maybe<Scalars['String']['output']>;
+  /** Queue up all the running workflows for sweep */
+  requeueSweep: Maybe<Scalars['String']['output']>;
+  /** Reruns the workflow from a specific task */
+  rerun: Maybe<Scalars['String']['output']>;
+  /** Resets callback times of all non-terminal SIMPLE tasks to 0 */
+  resetWorkflow: Maybe<Scalars['Void']['output']>;
+  /** Restarts a completed workflow */
+  restart: Maybe<Scalars['Void']['output']>;
+  /** Restart the list of completed workflow */
+  restart_1: Maybe<BulkResponse>;
+  /** Resumes the workflow */
+  resumeWorkflow: Maybe<Scalars['JSON']['output']>;
+  /** Resume the list of workflows */
+  resumeWorkflow_1: Maybe<BulkResponse>;
+  /** Retries the last failed task */
+  retry: Maybe<Scalars['Void']['output']>;
+  /** Retry the last failed task for each workflow from the list */
+  retry_1: Maybe<BulkResponse>;
+  /** Skips a given task from a current running workflow */
+  skipTaskFromWorkflow: Maybe<Scalars['JSON']['output']>;
+  /** Start a new workflow with StartWorkflowRequest, which allows task to be executed in a domain */
+  startWorkflow: Maybe<Scalars['String']['output']>;
+  /** Start a new workflow. Returns the ID of the workflow instance that can be later used for tracking */
+  startWorkflow_1: Maybe<Scalars['String']['output']>;
+  /** Terminate workflows execution */
+  terminate: Maybe<BulkResponse>;
+  /** Terminate workflow execution */
+  terminate_1: Maybe<Scalars['JSON']['output']>;
+  /** Remove a task definition */
+  unregisterTaskDef: Maybe<Scalars['JSON']['output']>;
+  /** Removes workflow definition. It does not remove workflows associated with the definition. */
+  unregisterWorkflowDef: Maybe<Scalars['JSON']['output']>;
+  /** Create or update workflow definition */
+  update: Maybe<BulkResponse>;
+  /** Publish a message in queue to mark a wait task (by taskId) as completed. */
+  updateByTaskId: Maybe<Scalars['JSON']['output']>;
+  /** Update an existing event handler. */
+  updateEventHandler: Maybe<Scalars['JSON']['output']>;
+  /** Update a task */
+  updateTask: Maybe<Scalars['String']['output']>;
+  /** Publish a message in queue to mark a wait task as completed. */
+  update_1: Maybe<Scalars['JSON']['output']>;
+  /** Validates a new workflow definition */
+  validate: Maybe<Scalars['JSON']['output']>;
+  /** Verify and repair workflow consistency */
+  verifyAndRepairWorkflowConsistency: Maybe<Scalars['String']['output']>;
+};
+
+
+export type ConductorMutationAddEventHandlerArgs = {
+  input?: InputMaybe<EventHandler_Input>;
+};
+
+
+export type ConductorMutationCreateArgs = {
+  input?: InputMaybe<WorkflowDef_Input>;
+};
+
+
+export type ConductorMutationDecideArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationDeleteArgs = {
+  archiveWorkflow?: InputMaybe<Scalars['Boolean']['input']>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationGetWorkflowsArgs = {
+  includeClosed?: InputMaybe<Scalars['Boolean']['input']>;
+  includeTasks?: InputMaybe<Scalars['Boolean']['input']>;
+  input?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  name: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationLogArgs = {
+  input?: InputMaybe<Scalars['String']['input']>;
+  taskId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationPauseWorkflowArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationPauseWorkflow_1Args = {
+  input?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ConductorMutationRegisterTaskDefArgs = {
+  input?: InputMaybe<TaskDef_Input>;
+};
+
+
+export type ConductorMutationRegisterTaskDef_1Args = {
+  input?: InputMaybe<Array<InputMaybe<TaskDef_Input>>>;
+};
+
+
+export type ConductorMutationRemoveEventHandlerStatusArgs = {
+  name: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationRequeuePendingTaskArgs = {
+  taskType: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationRequeueSweepArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationRerunArgs = {
+  input?: InputMaybe<RerunWorkflowRequest_Input>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationResetWorkflowArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationRestartArgs = {
+  useLatestDefinitions?: InputMaybe<Scalars['Boolean']['input']>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationRestart_1Args = {
+  input?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  useLatestDefinitions?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type ConductorMutationResumeWorkflowArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationResumeWorkflow_1Args = {
+  input?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ConductorMutationRetryArgs = {
+  resumeSubworkflowTasks?: InputMaybe<Scalars['Boolean']['input']>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationRetry_1Args = {
+  input?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ConductorMutationSkipTaskFromWorkflowArgs = {
+  skipTaskRequest: SkipTaskRequest_Input;
+  taskReferenceName: Scalars['String']['input'];
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationStartWorkflowArgs = {
+  input?: InputMaybe<StartWorkflowRequest_Input>;
+};
+
+
+export type ConductorMutationStartWorkflow_1Args = {
+  correlationId?: InputMaybe<Scalars['String']['input']>;
+  input?: InputMaybe<Scalars['JSON']['input']>;
+  name: Scalars['String']['input'];
+  priority?: InputMaybe<Scalars['Int']['input']>;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorMutationTerminateArgs = {
+  input?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  reason?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type ConductorMutationTerminate_1Args = {
+  reason?: InputMaybe<Scalars['String']['input']>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationUnregisterTaskDefArgs = {
+  tasktype: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationUnregisterWorkflowDefArgs = {
+  name: Scalars['String']['input'];
+  version: Scalars['Int']['input'];
+};
+
+
+export type ConductorMutationUpdateArgs = {
+  input?: InputMaybe<Array<InputMaybe<WorkflowDef_Input>>>;
+};
+
+
+export type ConductorMutationUpdateByTaskIdArgs = {
+  input?: InputMaybe<Scalars['JSON']['input']>;
+  status: MutationInput_UpdateByTaskId_Status;
+  taskId: Scalars['String']['input'];
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationUpdateEventHandlerArgs = {
+  input?: InputMaybe<EventHandler_Input>;
+};
+
+
+export type ConductorMutationUpdateTaskArgs = {
+  input?: InputMaybe<TaskResult_Input>;
+};
+
+
+export type ConductorMutationUpdate_1Args = {
+  input?: InputMaybe<Scalars['JSON']['input']>;
+  status: MutationInput_Update_1_Status;
+  taskRefName: Scalars['String']['input'];
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorMutationValidateArgs = {
+  input?: InputMaybe<WorkflowDef_Input>;
+};
+
+
+export type ConductorMutationVerifyAndRepairWorkflowConsistencyArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+export type ConductorQuery = {
+  __typename?: 'conductorQuery';
+  /** Get the details about each queue */
+  all: Maybe<Scalars['JSON']['output']>;
+  /** Get the details about each queue */
+  allVerbose: Maybe<Scalars['JSON']['output']>;
+  /** Batch poll for a task of a certain type */
+  batchPoll: Maybe<Array<Maybe<Task>>>;
+  doCheck: Maybe<HealthCheckStatus>;
+  /** Retrieves workflow definition along with blueprint */
+  get: Maybe<WorkflowDef>;
+  /** Retrieves all workflow definition along with blueprint */
+  getAll: Maybe<Array<Maybe<WorkflowDef>>>;
+  /** Get all the configuration parameters */
+  getAllConfig: Maybe<Scalars['JSON']['output']>;
+  /** Get the last poll data for all task types */
+  getAllPollData: Maybe<Array<Maybe<PollData>>>;
+  /** Get all the event handlers */
+  getEventHandlers: Maybe<Array<Maybe<EventHandler>>>;
+  /** Get event handlers for a given event */
+  getEventHandlersForEvent: Maybe<Array<Maybe<EventHandler>>>;
+  /** Get registered queues */
+  getEventQueues: Maybe<Scalars['JSON']['output']>;
+  /** Gets the workflow by workflow id */
+  getExecutionStatus: Maybe<Workflow>;
+  /** Get task or workflow by externalPayloadPath from External PostgreSQL Storage */
+  getExternalStorageData: Maybe<Scalars['File']['output']>;
+  /** Get the uri and path of the external storage where the workflow payload is to be stored */
+  getExternalStorageLocation: Maybe<ExternalStorageLocation>;
+  /** Get the external uri where the task payload is to be stored */
+  getExternalStorageLocation_1: Maybe<ExternalStorageLocation>;
+  /** Get the last poll data for a given task type */
+  getPollData: Maybe<Array<Maybe<PollData>>>;
+  /** Retrieve all the running workflows */
+  getRunningWorkflow: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** Get task by Id */
+  getTask: Maybe<Task>;
+  /** Gets the task definition */
+  getTaskDef: Maybe<TaskDef>;
+  /** Gets all task definition */
+  getTaskDefs: Maybe<Array<Maybe<TaskDef>>>;
+  /** Get Task Execution Logs */
+  getTaskLogs: Maybe<Array<Maybe<TaskExecLog>>>;
+  /** Gets the workflow by workflow id */
+  getWorkflowFamily: Maybe<Array<Maybe<Workflow>>>;
+  /** Returns workflow names and versions only (no definition bodies) */
+  getWorkflowNamesAndVersions: Maybe<Scalars['JSON']['output']>;
+  /** Gets the workflow by workflow id */
+  getWorkflowPath: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** Lists workflows for the given correlation id */
+  getWorkflows_1: Maybe<Array<Maybe<Workflow>>>;
+  /** Get Queue Names */
+  names: Maybe<Scalars['JSON']['output']>;
+  /** Poll for a task of a certain type */
+  poll: Maybe<Task>;
+  /** use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC. If order is not specified, defaults to ASC. */
+  search: Maybe<SearchResultWorkflowSummary>;
+  /** use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC. If order is not specified, defaults to ASC. */
+  searchV2: Maybe<SearchResultWorkflow>;
+  /** use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC. If order is not specified, defaults to ASC */
+  searchV2_1: Maybe<SearchResultTask>;
+  /** use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC. If order is not specified, defaults to ASC */
+  searchWorkflowsByTasks: Maybe<SearchResultWorkflowSummary>;
+  /** use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC. If order is not specified, defaults to ASC */
+  searchWorkflowsByTasksV2: Maybe<SearchResultWorkflow>;
+  /** use sort options as sort=<field>:ASC|DESC e.g. sort=name&sort=workflowId:DESC. If order is not specified, defaults to ASC */
+  search_1: Maybe<SearchResultTaskSummary>;
+  /**
+   * Deprecated. Please use /tasks/queue/size endpoint
+   * @deprecated deprecated
+   */
+  size: Maybe<Scalars['JSON']['output']>;
+  /** Get the queue length */
+  size_1: Maybe<Scalars['JSON']['output']>;
+  /** Get queue size for a task type. */
+  taskDepth: Maybe<Scalars['Int']['output']>;
+  /** Get the list of pending tasks for a given task type */
+  view: Maybe<Array<Maybe<Task>>>;
+};
+
+
+export type ConductorQueryBatchPollArgs = {
+  count?: InputMaybe<Scalars['Int']['input']>;
+  domain?: InputMaybe<Scalars['String']['input']>;
+  tasktype: Scalars['String']['input'];
+  timeout?: InputMaybe<Scalars['Int']['input']>;
+  workerid?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type ConductorQueryGetArgs = {
+  name: Scalars['String']['input'];
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQueryGetEventHandlersForEventArgs = {
+  activeOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  event: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetEventQueuesArgs = {
+  verbose?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type ConductorQueryGetExecutionStatusArgs = {
+  includeTasks?: InputMaybe<Scalars['Boolean']['input']>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetExternalStorageDataArgs = {
+  externalPayloadPath: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetExternalStorageLocationArgs = {
+  operation: Scalars['String']['input'];
+  path: Scalars['String']['input'];
+  payloadType: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetExternalStorageLocation_1Args = {
+  operation: Scalars['String']['input'];
+  path: Scalars['String']['input'];
+  payloadType: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetPollDataArgs = {
+  taskType: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetRunningWorkflowArgs = {
+  endTime?: InputMaybe<Scalars['BigInt']['input']>;
+  name: Scalars['String']['input'];
+  startTime?: InputMaybe<Scalars['BigInt']['input']>;
+  version?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQueryGetTaskArgs = {
+  taskId: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetTaskDefArgs = {
+  tasktype: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetTaskLogsArgs = {
+  taskId: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetWorkflowFamilyArgs = {
+  summaryOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetWorkflowPathArgs = {
+  workflowId: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryGetWorkflows_1Args = {
+  correlationId: Scalars['String']['input'];
+  includeClosed?: InputMaybe<Scalars['Boolean']['input']>;
+  includeTasks?: InputMaybe<Scalars['Boolean']['input']>;
+  name: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryPollArgs = {
+  domain?: InputMaybe<Scalars['String']['input']>;
+  tasktype: Scalars['String']['input'];
+  workerid?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type ConductorQuerySearchArgs = {
+  freeText?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQuerySearchV2Args = {
+  freeText?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQuerySearchV2_1Args = {
+  freeText?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQuerySearchWorkflowsByTasksArgs = {
+  freeText?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQuerySearchWorkflowsByTasksV2Args = {
+  freeText?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQuerySearch_1Args = {
+  freeText?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ConductorQuerySizeArgs = {
+  taskType?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type ConductorQueryTaskDepthArgs = {
+  domain?: InputMaybe<Scalars['String']['input']>;
+  executionNamespace?: InputMaybe<Scalars['String']['input']>;
+  isolationGroupId?: InputMaybe<Scalars['String']['input']>;
+  taskType: Scalars['String']['input'];
+};
+
+
+export type ConductorQueryViewArgs = {
+  count?: InputMaybe<Scalars['Int']['input']>;
+  start?: InputMaybe<Scalars['Int']['input']>;
+  tasktype: Scalars['String']['input'];
+};
+
+export type DeviceInventoryMutation = {
+  __typename?: 'deviceInventoryMutation';
+  addBlueprint: AddBlueprintPayload;
+  addDevice: AddDevicePayload;
+  addLocation: AddLocationPayload;
+  addSnapshot: Maybe<AddSnapshotPayload>;
+  addZone: AddZonePayload;
+  applySnapshot: ApplySnapshotPayload;
+  bulkInstallDevices: BulkInstallDevicePayload;
+  bulkUninstallDevices: BulkUninstallDevicePayload;
+  closeTransaction: CloseTransactionPayload;
+  commitConfig: CommitConfigPayload;
+  createLabel: CreateLabelPayload;
+  createTransaction: CreateTransactionPayload;
+  deleteBlueprint: DeleteBlueprintPayload;
+  deleteDevice: DeleteDevicePayload;
+  deleteLabel: DeleteLabelPayload;
+  deleteSnapshot: Maybe<DeleteSnapshotPayload>;
+  importCSV: Maybe<CsvImport>;
+  installDevice: InstallDevicePayload;
+  resetConfig: ResetConfigPayload;
+  revertChanges: RevertChangesPayload;
+  syncFromNetwork: SyncFromNetworkPayload;
+  uninstallDevice: UninstallDevicePayload;
+  updateBlueprint: UpdateBlueprintPayload;
+  updateDataStore: UpdateDataStorePayload;
+  updateDevice: UpdateDevicePayload;
+  updateGraphNodeCoordinates: UpdateGraphNodeCoordinatesPayload;
+};
+
+
+export type DeviceInventoryMutationAddBlueprintArgs = {
+  input: AddBlueprintInput;
+};
+
+
+export type DeviceInventoryMutationAddDeviceArgs = {
+  input: AddDeviceInput;
+};
+
+
+export type DeviceInventoryMutationAddLocationArgs = {
+  input: AddLocationInput;
+};
+
+
+export type DeviceInventoryMutationAddSnapshotArgs = {
+  input: AddSnapshotInput;
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationAddZoneArgs = {
+  input: AddZoneInput;
+};
+
+
+export type DeviceInventoryMutationApplySnapshotArgs = {
+  input: ApplySnapshotInput;
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationBulkInstallDevicesArgs = {
+  input: BulkInstallDevicesInput;
+};
+
+
+export type DeviceInventoryMutationBulkUninstallDevicesArgs = {
+  input: BulkUninstallDevicesInput;
+};
+
+
+export type DeviceInventoryMutationCloseTransactionArgs = {
+  deviceId: Scalars['String']['input'];
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationCommitConfigArgs = {
+  input: CommitConfigInput;
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationCreateLabelArgs = {
+  input: CreateLabelInput;
+};
+
+
+export type DeviceInventoryMutationCreateTransactionArgs = {
+  deviceId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationDeleteBlueprintArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationDeleteDeviceArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationDeleteLabelArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationDeleteSnapshotArgs = {
+  input: DeleteSnapshotInput;
+};
+
+
+export type DeviceInventoryMutationImportCsvArgs = {
+  input: CsvImportInput;
+};
+
+
+export type DeviceInventoryMutationInstallDeviceArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationResetConfigArgs = {
+  deviceId: Scalars['String']['input'];
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationRevertChangesArgs = {
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationSyncFromNetworkArgs = {
+  deviceId: Scalars['String']['input'];
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationUninstallDeviceArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationUpdateBlueprintArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateBlueprintInput;
+};
+
+
+export type DeviceInventoryMutationUpdateDataStoreArgs = {
+  deviceId: Scalars['String']['input'];
+  input: UpdateDataStoreInput;
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryMutationUpdateDeviceArgs = {
+  id: Scalars['String']['input'];
+  input: UpdateDeviceInput;
+};
+
+
+export type DeviceInventoryMutationUpdateGraphNodeCoordinatesArgs = {
+  input: Array<GraphNodeCoordinatesInput>;
+};
+
+export type DeviceInventoryQuery = {
+  __typename?: 'deviceInventoryQuery';
+  blueprints: BlueprintConnection;
+  calculatedDiff: CalculatedDiffPayload;
+  countries: CountryConnection;
+  dataStore: Maybe<DataStore>;
+  devices: DeviceConnection;
+  labels: LabelConnection;
+  locations: LocationConnection;
+  netTopology: Maybe<NetTopology>;
+  node: Maybe<Node>;
+  shortestPath: Array<NetRoutingPathNode>;
+  topology: Maybe<Topology>;
+  topologyCommonNodes: Maybe<TopologyCommonNodes>;
+  topologyVersionData: TopologyVersionData;
+  topologyVersions: Maybe<Array<Scalars['String']['output']>>;
+  transactions: Array<Transaction>;
+  uniconfigShellSession: Maybe<Scalars['String']['output']>;
+  zones: ZonesConnection;
+};
+
+
+export type DeviceInventoryQueryBlueprintsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type DeviceInventoryQueryCalculatedDiffArgs = {
+  deviceId: Scalars['String']['input'];
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryQueryCountriesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type DeviceInventoryQueryDataStoreArgs = {
+  deviceId: Scalars['String']['input'];
+  transactionId: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryQueryDevicesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<FilterDevicesInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<DeviceOrderByInput>;
+};
+
+
+export type DeviceInventoryQueryLabelsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<FilterLabelsInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type DeviceInventoryQueryLocationsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type DeviceInventoryQueryNodeArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type DeviceInventoryQueryShortestPathArgs = {
+  from: Scalars['String']['input'];
+  to: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryQueryTopologyArgs = {
+  filter?: InputMaybe<FilterTopologyInput>;
+};
+
+
+export type DeviceInventoryQueryTopologyCommonNodesArgs = {
+  nodes: Array<Scalars['String']['input']>;
+};
+
+
+export type DeviceInventoryQueryTopologyVersionDataArgs = {
+  version: Scalars['String']['input'];
+};
+
+
+export type DeviceInventoryQueryZonesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<FilterZonesInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type DeviceInventorySubscription = {
+  __typename?: 'deviceInventorySubscription';
+  uniconfigShell: Maybe<Scalars['String']['output']>;
+};
+
+
+export type DeviceInventorySubscriptionUniconfigShellArgs = {
+  input?: InputMaybe<Scalars['String']['input']>;
+  sessionId: Scalars['String']['input'];
+  trigger?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type MutationInput_UpdateByTaskId_Status =
+  | 'CANCELED'
+  | 'COMPLETED'
+  | 'COMPLETED_WITH_ERRORS'
+  | 'FAILED'
+  | 'FAILED_WITH_TERMINAL_ERROR'
+  | 'IN_PROGRESS'
+  | 'SCHEDULED'
+  | 'SKIPPED'
+  | 'TIMED_OUT';
+
+export type MutationInput_UpdateEventHandler_Input_Actions_Items_Action =
+  | 'complete_task'
+  | 'fail_task'
+  | 'start_workflow';
+
+export type MutationInput_UpdateTask_Input_Status =
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'FAILED_WITH_TERMINAL_ERROR'
+  | 'IN_PROGRESS';
+
+export type MutationInput_Update_1_Status =
+  | 'CANCELED'
+  | 'COMPLETED'
+  | 'COMPLETED_WITH_ERRORS'
+  | 'FAILED'
+  | 'FAILED_WITH_TERMINAL_ERROR'
+  | 'IN_PROGRESS'
+  | 'SCHEDULED'
+  | 'SKIPPED'
+  | 'TIMED_OUT';
+
+export type Mutation_GetWorkflows_AdditionalProperties_Items_Status =
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'PAUSED'
+  | 'RUNNING'
+  | 'TERMINATED'
+  | 'TIMED_OUT';
+
+export type Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_Status =
+  | 'CANCELED'
+  | 'COMPLETED'
+  | 'COMPLETED_WITH_ERRORS'
+  | 'FAILED'
+  | 'FAILED_WITH_TERMINAL_ERROR'
+  | 'IN_PROGRESS'
+  | 'SCHEDULED'
+  | 'SKIPPED'
+  | 'TIMED_OUT';
+
+export type Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_SubWorkflowParam_WorkflowDefinition_TimeoutPolicy =
+  | 'ALERT_ONLY'
+  | 'TIME_OUT_WF';
+
+export type Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_TaskDefinition_RetryLogic =
+  | 'EXPONENTIAL_BACKOFF'
+  | 'FIXED'
+  | 'LINEAR_BACKOFF';
+
+export type Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_TaskDefinition_TimeoutPolicy =
+  | 'ALERT_ONLY'
+  | 'RETRY'
+  | 'TIME_OUT_WF';
+
+export type Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_WorkflowTaskType =
+  | 'DECISION'
+  | 'DO_WHILE'
+  | 'DYNAMIC'
+  | 'EVENT'
+  | 'EXCLUSIVE_JOIN'
+  | 'FORK_JOIN'
+  | 'FORK_JOIN_DYNAMIC'
+  | 'HTTP'
+  | 'HUMAN'
+  | 'INLINE'
+  | 'JOIN'
+  | 'JSON_JQ_TRANSFORM'
+  | 'KAFKA_PUBLISH'
+  | 'LAMBDA'
+  | 'SET_VARIABLE'
+  | 'SIMPLE'
+  | 'START_WORKFLOW'
+  | 'SUB_WORKFLOW'
+  | 'SWITCH'
+  | 'TERMINATE'
+  | 'USER_DEFINED'
+  | 'WAIT';
+
+export type Query_Search_1_Results_Items_Status =
+  | 'CANCELED'
+  | 'COMPLETED'
+  | 'COMPLETED_WITH_ERRORS'
+  | 'FAILED'
+  | 'FAILED_WITH_TERMINAL_ERROR'
+  | 'IN_PROGRESS'
+  | 'SCHEDULED'
+  | 'SKIPPED'
+  | 'TIMED_OUT';
+
+export type Query_Search_Results_Items_Status =
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'PAUSED'
+  | 'RUNNING'
+  | 'TERMINATED'
+  | 'TIMED_OUT';
+
 export type UploadFileMutationVariables = Exact<{
   input: CsvImportInput;
 }>;
 
 
-export type UploadFileMutation = { __typename?: 'Mutation', importCSV: { __typename?: 'CSVImport', isOk: boolean | null } | null };
+export type UploadFileMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', importCSV: { __typename?: 'CSVImport', isOk: boolean | null } | null } };
 
 export type ZonesImportQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ZonesImportQuery = { __typename?: 'Query', zones: { __typename?: 'ZonesConnection', edges: Array<{ __typename?: 'ZoneEdge', node: { __typename?: 'Zone', id: string, name: string } }> } };
+export type ZonesImportQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', zones: { __typename?: 'ZonesConnection', edges: Array<{ __typename?: 'ZoneEdge', node: { __typename?: 'Zone', id: string, name: string } }> } } };
 
 export type AddBlueprintMutationVariables = Exact<{
   input: AddBlueprintInput;
 }>;
 
 
-export type AddBlueprintMutation = { __typename?: 'Mutation', addBlueprint: { __typename?: 'AddBlueprintPayload', blueprint: { __typename?: 'Blueprint', id: string, createdAt: string, name: string } } };
+export type AddBlueprintMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', addBlueprint: { __typename?: 'AddBlueprintPayload', blueprint: { __typename?: 'Blueprint', id: string, createdAt: string, name: string } } } };
 
 export type AddDeviceMutationVariables = Exact<{
   input: AddDeviceInput;
 }>;
 
 
-export type AddDeviceMutation = { __typename?: 'Mutation', addDevice: { __typename?: 'AddDevicePayload', device: { __typename?: 'Device', id: string, name: string, isInstalled: boolean, zone: { __typename?: 'Zone', id: string, name: string } } } };
+export type AddDeviceMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', addDevice: { __typename?: 'AddDevicePayload', device: { __typename?: 'Device', id: string, name: string, isInstalled: boolean, zone: { __typename?: 'Zone', id: string, name: string } } } } };
 
 export type ZonesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ZonesQuery = { __typename?: 'Query', zones: { __typename?: 'ZonesConnection', edges: Array<{ __typename?: 'ZoneEdge', node: { __typename?: 'Zone', id: string, name: string } }> } };
+export type ZonesQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', zones: { __typename?: 'ZonesConnection', edges: Array<{ __typename?: 'ZoneEdge', node: { __typename?: 'Zone', id: string, name: string } }> } } };
 
 export type DeviceBlueprintsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type DeviceBlueprintsQuery = { __typename?: 'Query', blueprints: { __typename?: 'BlueprintConnection', edges: Array<{ __typename?: 'BlueprintEdge', node: { __typename?: 'Blueprint', id: string, name: string, template: string } }> } };
+export type DeviceBlueprintsQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', blueprints: { __typename?: 'BlueprintConnection', edges: Array<{ __typename?: 'BlueprintEdge', node: { __typename?: 'Blueprint', id: string, name: string, template: string } }> } } };
 
 export type CreateLabelMutationVariables = Exact<{
   input: CreateLabelInput;
 }>;
 
 
-export type CreateLabelMutation = { __typename?: 'Mutation', newLabel: { __typename?: 'CreateLabelPayload', label: { __typename?: 'Label', id: string, name: string, createdAt: string, updatedAt: string } | null } };
+export type CreateLabelMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', newLabel: { __typename?: 'CreateLabelPayload', label: { __typename?: 'Label', id: string, name: string, createdAt: string, updatedAt: string } | null } } };
 
 export type LabelsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LabelsQuery = { __typename?: 'Query', labels: { __typename?: 'LabelConnection', edges: Array<{ __typename?: 'LabelEdge', node: { __typename?: 'Label', id: string, name: string } }> } };
+export type LabelsQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', labels: { __typename?: 'LabelConnection', edges: Array<{ __typename?: 'LabelEdge', node: { __typename?: 'Label', id: string, name: string } }> } } };
 
 export type BlueprintsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type BlueprintsQuery = { __typename?: 'Query', blueprints: { __typename?: 'BlueprintConnection', edges: Array<{ __typename?: 'BlueprintEdge', node: { __typename?: 'Blueprint', id: string, createdAt: string, name: string } }> } };
+export type BlueprintsQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', blueprints: { __typename?: 'BlueprintConnection', edges: Array<{ __typename?: 'BlueprintEdge', node: { __typename?: 'Blueprint', id: string, createdAt: string, name: string } }> } } };
 
 export type DeleteBlueprintMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type DeleteBlueprintMutation = { __typename?: 'Mutation', deleteBlueprint: { __typename?: 'DeleteBlueprintPayload', blueprint: { __typename?: 'Blueprint', id: string } | null } };
+export type DeleteBlueprintMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', deleteBlueprint: { __typename?: 'DeleteBlueprintPayload', blueprint: { __typename?: 'Blueprint', id: string } | null } } };
 
 export type DeviceNameQueryVariables = Exact<{
   deviceId: Scalars['ID']['input'];
 }>;
 
 
-export type DeviceNameQuery = { __typename?: 'Query', node: { __typename?: 'Blueprint' } | { __typename?: 'Country' } | { __typename?: 'Device', id: string, name: string } | { __typename?: 'EventHandler' } | { __typename?: 'ExecutedWorkflow' } | { __typename?: 'ExecutedWorkflowTask' } | { __typename?: 'Label' } | { __typename?: 'Location' } | { __typename?: 'Pool' } | { __typename?: 'Schedule' } | { __typename?: 'TaskDefinition' } | { __typename?: 'Workflow' } | { __typename?: 'Zone' } | null };
+export type DeviceNameQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', node: { __typename?: 'Blueprint' } | { __typename?: 'Country' } | { __typename?: 'Device', id: string, name: string } | { __typename?: 'Label' } | { __typename?: 'Location' } | { __typename?: 'Zone' } | null } };
 
 export type DataStoreQueryVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2047,7 +2188,7 @@ export type DataStoreQueryVariables = Exact<{
 }>;
 
 
-export type DataStoreQuery = { __typename?: 'Query', dataStore: { __typename?: 'DataStore', config: string, operational: string, snapshots: Array<{ __typename?: 'Snapshot', name: string, createdAt: string }> } | null };
+export type DataStoreQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', dataStore: { __typename?: 'DataStore', config: string, operational: string, snapshots: Array<{ __typename?: 'Snapshot', name: string, createdAt: string }> } | null } };
 
 export type UpdateDataStoreMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2056,7 +2197,7 @@ export type UpdateDataStoreMutationVariables = Exact<{
 }>;
 
 
-export type UpdateDataStoreMutation = { __typename?: 'Mutation', updateDataStore: { __typename?: 'UpdateDataStorePayload', dataStore: { __typename?: 'DataStore', config: string, operational: string } } };
+export type UpdateDataStoreMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', updateDataStore: { __typename?: 'UpdateDataStorePayload', dataStore: { __typename?: 'DataStore', config: string, operational: string } } } };
 
 export type CommitDataStoreConfigMutationVariables = Exact<{
   transactionId: Scalars['String']['input'];
@@ -2064,7 +2205,7 @@ export type CommitDataStoreConfigMutationVariables = Exact<{
 }>;
 
 
-export type CommitDataStoreConfigMutation = { __typename?: 'Mutation', commitConfig: { __typename?: 'CommitConfigPayload', output: { __typename?: 'CommitConfigOutput', configuration: string | null, message: string | null } } };
+export type CommitDataStoreConfigMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', commitConfig: { __typename?: 'CommitConfigPayload', output: { __typename?: 'CommitConfigOutput', configuration: string | null, message: string | null } } } };
 
 export type ResetConfigMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2072,7 +2213,7 @@ export type ResetConfigMutationVariables = Exact<{
 }>;
 
 
-export type ResetConfigMutation = { __typename?: 'Mutation', resetConfig: { __typename?: 'ResetConfigPayload', dataStore: { __typename?: 'DataStore', config: string, operational: string } } };
+export type ResetConfigMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', resetConfig: { __typename?: 'ResetConfigPayload', dataStore: { __typename?: 'DataStore', config: string, operational: string } } } };
 
 export type AddSnapshotMutationVariables = Exact<{
   transactionId: Scalars['String']['input'];
@@ -2080,7 +2221,7 @@ export type AddSnapshotMutationVariables = Exact<{
 }>;
 
 
-export type AddSnapshotMutation = { __typename?: 'Mutation', addSnapshot: { __typename?: 'AddSnapshotPayload', snapshot: { __typename?: 'Snapshot', name: string } | null } | null };
+export type AddSnapshotMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', addSnapshot: { __typename?: 'AddSnapshotPayload', snapshot: { __typename?: 'Snapshot', name: string } | null } | null } };
 
 export type ApplySnapshotMutationVariables = Exact<{
   transactionId: Scalars['String']['input'];
@@ -2088,7 +2229,7 @@ export type ApplySnapshotMutationVariables = Exact<{
 }>;
 
 
-export type ApplySnapshotMutation = { __typename?: 'Mutation', applySnapshot: { __typename?: 'ApplySnapshotPayload', isOk: boolean, output: string } };
+export type ApplySnapshotMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', applySnapshot: { __typename?: 'ApplySnapshotPayload', isOk: boolean, output: string } } };
 
 export type SyncFromNetworkMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2096,21 +2237,21 @@ export type SyncFromNetworkMutationVariables = Exact<{
 }>;
 
 
-export type SyncFromNetworkMutation = { __typename?: 'Mutation', syncFromNetwork: { __typename?: 'SyncFromNetworkPayload', dataStore: { __typename?: 'DataStore', operational: string } | null } };
+export type SyncFromNetworkMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', syncFromNetwork: { __typename?: 'SyncFromNetworkPayload', dataStore: { __typename?: 'DataStore', operational: string } | null } } };
 
 export type DeleteSnapshotMutationVariables = Exact<{
   input: DeleteSnapshotInput;
 }>;
 
 
-export type DeleteSnapshotMutation = { __typename?: 'Mutation', deleteSnapshot: { __typename?: 'DeleteSnapshotPayload', snapshot: { __typename?: 'Snapshot', name: string } | null } | null };
+export type DeleteSnapshotMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', deleteSnapshot: { __typename?: 'DeleteSnapshotPayload', snapshot: { __typename?: 'Snapshot', name: string } | null } | null } };
 
 export type CreateTransactionMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
 }>;
 
 
-export type CreateTransactionMutation = { __typename?: 'Mutation', createTransaction: { __typename?: 'CreateTransactionPayload', transactionId: string | null } };
+export type CreateTransactionMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', createTransaction: { __typename?: 'CreateTransactionPayload', transactionId: string | null } } };
 
 export type CloseTransactionMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2118,7 +2259,7 @@ export type CloseTransactionMutationVariables = Exact<{
 }>;
 
 
-export type CloseTransactionMutation = { __typename?: 'Mutation', closeTransaction: { __typename?: 'CloseTransactionPayload', isOk: boolean } };
+export type CloseTransactionMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', closeTransaction: { __typename?: 'CloseTransactionPayload', isOk: boolean } } };
 
 export type CalculatedDiffQueryVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2126,7 +2267,7 @@ export type CalculatedDiffQueryVariables = Exact<{
 }>;
 
 
-export type CalculatedDiffQuery = { __typename?: 'Query', calculatedDiff: { __typename?: 'CalculatedDiffPayload', result: { __typename?: 'CalculatedDiffResult', createdData: Array<{ __typename?: 'DiffData', path: string, data: string }>, deletedData: Array<{ __typename?: 'DiffData', path: string, data: string }>, updatedData: Array<{ __typename?: 'CalculatedUpdateDiffData', path: string, actualData: string, intendedData: string }> } } };
+export type CalculatedDiffQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', calculatedDiff: { __typename?: 'CalculatedDiffPayload', result: { __typename?: 'CalculatedDiffResult', createdData: Array<{ __typename?: 'DiffData', path: string, data: string }>, deletedData: Array<{ __typename?: 'DiffData', path: string, data: string }>, updatedData: Array<{ __typename?: 'CalculatedUpdateDiffData', path: string, actualData: string, intendedData: string }> } } } };
 
 export type DevicesQueryVariables = Exact<{
   labels?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
@@ -2139,59 +2280,59 @@ export type DevicesQueryVariables = Exact<{
 }>;
 
 
-export type DevicesQuery = { __typename?: 'Query', devices: { __typename?: 'DeviceConnection', edges: Array<{ __typename?: 'DeviceEdge', node: { __typename?: 'Device', id: string, name: string, createdAt: string, isInstalled: boolean, serviceState: DeviceServiceState, zone: { __typename?: 'Zone', id: string, name: string } } }>, pageInfo: { __typename?: 'PageInfo', startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
+export type DevicesQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', devices: { __typename?: 'DeviceConnection', edges: Array<{ __typename?: 'DeviceEdge', node: { __typename?: 'Device', id: string, name: string, createdAt: string, isInstalled: boolean, serviceState: DeviceServiceState, zone: { __typename?: 'Zone', id: string, name: string } } }>, pageInfo: { __typename?: 'PageInfo', startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } } };
 
 export type InstallDeviceMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type InstallDeviceMutation = { __typename?: 'Mutation', installDevice: { __typename?: 'InstallDevicePayload', device: { __typename?: 'Device', id: string, createdAt: string, isInstalled: boolean, serviceState: DeviceServiceState } } };
+export type InstallDeviceMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', installDevice: { __typename?: 'InstallDevicePayload', device: { __typename?: 'Device', id: string, createdAt: string, isInstalled: boolean, serviceState: DeviceServiceState } } } };
 
 export type UninstallDeviceMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type UninstallDeviceMutation = { __typename?: 'Mutation', uninstallDevice: { __typename?: 'UninstallDevicePayload', device: { __typename?: 'Device', id: string, createdAt: string, isInstalled: boolean, serviceState: DeviceServiceState } } };
+export type UninstallDeviceMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', uninstallDevice: { __typename?: 'UninstallDevicePayload', device: { __typename?: 'Device', id: string, createdAt: string, isInstalled: boolean, serviceState: DeviceServiceState } } } };
 
 export type FilterLabelsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type FilterLabelsQuery = { __typename?: 'Query', labels: { __typename?: 'LabelConnection', edges: Array<{ __typename?: 'LabelEdge', node: { __typename?: 'Label', id: string, name: string } }> } };
+export type FilterLabelsQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', labels: { __typename?: 'LabelConnection', edges: Array<{ __typename?: 'LabelEdge', node: { __typename?: 'Label', id: string, name: string } }> } } };
 
 export type DeleteDeviceMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
 }>;
 
 
-export type DeleteDeviceMutation = { __typename?: 'Mutation', deleteDevice: { __typename?: 'DeleteDevicePayload', device: { __typename?: 'Device', id: string } | null } };
+export type DeleteDeviceMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', deleteDevice: { __typename?: 'DeleteDevicePayload', device: { __typename?: 'Device', id: string } | null } } };
 
 export type BulkInstallDevicesMutationVariables = Exact<{
   input: BulkInstallDevicesInput;
 }>;
 
 
-export type BulkInstallDevicesMutation = { __typename?: 'Mutation', bulkInstallDevices: { __typename?: 'BulkInstallDevicePayload', installedDevices: Array<{ __typename?: 'Device', id: string }> } };
+export type BulkInstallDevicesMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', bulkInstallDevices: { __typename?: 'BulkInstallDevicePayload', installedDevices: Array<{ __typename?: 'Device', id: string }> } } };
 
 export type ExecuteModalWorkflowByNameMutationVariables = Exact<{
-  input: ExecuteWorkflowByName;
+  input?: InputMaybe<StartWorkflowRequest_Input>;
 }>;
 
 
-export type ExecuteModalWorkflowByNameMutation = { __typename?: 'Mutation', executeWorkflowByName: string | null };
+export type ExecuteModalWorkflowByNameMutation = { __typename?: 'Mutation', conductor: { __typename?: 'conductorMutation', startWorkflow: string | null } };
 
 export type ModalWorkflowsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ModalWorkflowsQuery = { __typename?: 'Query', workflows: { __typename?: 'WorkflowConnection', totalCount: number, edges: Array<{ __typename?: 'WorkflowEdge', node: { __typename?: 'Workflow', id: string, name: string, description: string | null, version: number | null, createdAt: string | null, updatedAt: string | null, createdBy: string | null, updatedBy: string | null, tasks: string | null, hasSchedule: boolean | null, inputParameters: Array<string> | null, restartable: boolean | null, timeoutSeconds: number, timeoutPolicy: TimeoutPolicy | null, ownerEmail: string | null, schemaVersion: number | null, variables: any | null, outputParameters: Array<{ __typename?: 'OutputParameter', key: string, value: string }> | null } }>, pageInfo: { __typename?: 'PageInfo', startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
+export type ModalWorkflowsQuery = { __typename?: 'Query', conductor: { __typename?: 'conductorQuery', getAll: Array<{ __typename?: 'WorkflowDef', name: string, description: string | null, version: number | null, createdBy: string | null, updatedBy: string | null, inputParameters: Array<string | null> | null, outputParameters: any | null, restartable: boolean | null, timeoutSeconds: any, timeoutPolicy: Mutation_GetWorkflows_AdditionalProperties_Items_Tasks_Items_WorkflowTask_SubWorkflowParam_WorkflowDefinition_TimeoutPolicy | null, ownerEmail: string | null, schemaVersion: number | null, variables: any | null } | null> | null } };
 
 export type BlueprintQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type BlueprintQuery = { __typename?: 'Query', blueprint: { __typename?: 'Blueprint', name: string, template: string, id: string } | { __typename?: 'Country', id: string } | { __typename?: 'Device', id: string } | { __typename?: 'EventHandler', id: string } | { __typename?: 'ExecutedWorkflow', id: string } | { __typename?: 'ExecutedWorkflowTask', id: string } | { __typename?: 'Label', id: string } | { __typename?: 'Location', id: string } | { __typename?: 'Pool', id: string } | { __typename?: 'Schedule', id: string } | { __typename?: 'TaskDefinition', id: string } | { __typename?: 'Workflow', id: string } | { __typename?: 'Zone', id: string } | null };
+export type BlueprintQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', blueprint: { __typename?: 'Blueprint', name: string, template: string, id: string } | { __typename?: 'Country', id: string } | { __typename?: 'Device', id: string } | { __typename?: 'Label', id: string } | { __typename?: 'Location', id: string } | { __typename?: 'Zone', id: string } | null } };
 
 export type UpdateBlueprintMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -2199,14 +2340,14 @@ export type UpdateBlueprintMutationVariables = Exact<{
 }>;
 
 
-export type UpdateBlueprintMutation = { __typename?: 'Mutation', updateBlueprint: { __typename?: 'UpdateBlueprintPayload', blueprint: { __typename?: 'Blueprint', id: string, name: string, template: string } } };
+export type UpdateBlueprintMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', updateBlueprint: { __typename?: 'UpdateBlueprintPayload', blueprint: { __typename?: 'Blueprint', id: string, name: string, template: string } } } };
 
 export type DeviceQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type DeviceQuery = { __typename?: 'Query', device: { __typename?: 'Blueprint', id: string } | { __typename?: 'Country', id: string } | { __typename?: 'Device', name: string, serviceState: DeviceServiceState, model: string | null, vendor: string | null, address: string | null, deviceSize: DeviceSize, mountParameters: string | null, id: string, zone: { __typename?: 'Zone', id: string, name: string }, labels: { __typename?: 'LabelConnection', edges: Array<{ __typename?: 'LabelEdge', node: { __typename?: 'Label', id: string, name: string } }> } } | { __typename?: 'EventHandler', id: string } | { __typename?: 'ExecutedWorkflow', id: string } | { __typename?: 'ExecutedWorkflowTask', id: string } | { __typename?: 'Label', id: string } | { __typename?: 'Location', id: string } | { __typename?: 'Pool', id: string } | { __typename?: 'Schedule', id: string } | { __typename?: 'TaskDefinition', id: string } | { __typename?: 'Workflow', id: string } | { __typename?: 'Zone', id: string } | null };
+export type DeviceQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', device: { __typename?: 'Blueprint', id: string } | { __typename?: 'Country', id: string } | { __typename?: 'Device', name: string, serviceState: DeviceServiceState, model: string | null, vendor: string | null, address: string | null, deviceSize: DeviceSize, mountParameters: string | null, id: string, zone: { __typename?: 'Zone', id: string, name: string }, labels: { __typename?: 'LabelConnection', edges: Array<{ __typename?: 'LabelEdge', node: { __typename?: 'Label', id: string, name: string } }> } } | { __typename?: 'Label', id: string } | { __typename?: 'Location', id: string } | { __typename?: 'Zone', id: string } | null } };
 
 export type UpdateDeviceMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -2214,19 +2355,19 @@ export type UpdateDeviceMutationVariables = Exact<{
 }>;
 
 
-export type UpdateDeviceMutation = { __typename?: 'Mutation', updateDevice: { __typename?: 'UpdateDevicePayload', device: { __typename?: 'Device', id: string, name: string, model: string | null, vendor: string | null, address: string | null, isInstalled: boolean, zone: { __typename?: 'Zone', id: string, name: string } } | null } };
+export type UpdateDeviceMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', updateDevice: { __typename?: 'UpdateDevicePayload', device: { __typename?: 'Device', id: string, name: string, model: string | null, vendor: string | null, address: string | null, isInstalled: boolean, zone: { __typename?: 'Zone', id: string, name: string } } | null } } };
 
 export type TransactionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TransactionsQuery = { __typename?: 'Query', transactions: Array<{ __typename?: 'Transaction', transactionId: string, lastCommitTime: string, changes: Array<{ __typename?: 'TransactionChange', device: { __typename?: 'Device', id: string, name: string }, diff: Array<{ __typename?: 'TransactionDiff', path: string, dataBefore: string | null, dataAfter: string | null }> }> }> };
+export type TransactionsQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', transactions: Array<{ __typename?: 'Transaction', transactionId: string, lastCommitTime: string, changes: Array<{ __typename?: 'TransactionChange', device: { __typename?: 'Device', id: string, name: string }, diff: Array<{ __typename?: 'TransactionDiff', path: string, dataBefore: string | null, dataAfter: string | null }> }> }> } };
 
 export type RevertChangesMutationVariables = Exact<{
   transactionId: Scalars['String']['input'];
 }>;
 
 
-export type RevertChangesMutation = { __typename?: 'Mutation', revertChanges: { __typename?: 'RevertChangesPayload', isOk: boolean } };
+export type RevertChangesMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', revertChanges: { __typename?: 'RevertChangesPayload', isOk: boolean } } };
 
 export type CloseTransactionListMutationVariables = Exact<{
   deviceId: Scalars['String']['input'];
@@ -2234,7 +2375,7 @@ export type CloseTransactionListMutationVariables = Exact<{
 }>;
 
 
-export type CloseTransactionListMutation = { __typename?: 'Mutation', closeTransaction: { __typename?: 'CloseTransactionPayload', isOk: boolean } };
+export type CloseTransactionListMutation = { __typename?: 'Mutation', deviceInventory: { __typename?: 'deviceInventoryMutation', closeTransaction: { __typename?: 'CloseTransactionPayload', isOk: boolean } } };
 
 export type TerminalSubscriptionVariables = Exact<{
   sessionId: Scalars['String']['input'];
@@ -2243,9 +2384,9 @@ export type TerminalSubscriptionVariables = Exact<{
 }>;
 
 
-export type TerminalSubscription = { __typename?: 'Subscription', uniconfigShell: string | null };
+export type TerminalSubscription = { __typename?: 'Subscription', deviceInventory: { __typename?: 'deviceInventorySubscription', uniconfigShell: string | null } };
 
 export type SessionIdQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SessionIdQuery = { __typename?: 'Query', uniconfigShellSession: string | null };
+export type SessionIdQuery = { __typename?: 'Query', deviceInventory: { __typename?: 'deviceInventoryQuery', uniconfigShellSession: string | null } };

--- a/packages/frinx-inventory-client/src/components/import-csv-modal.tsx
+++ b/packages/frinx-inventory-client/src/components/import-csv-modal.tsx
@@ -29,18 +29,22 @@ import {
 
 const UPLOAD_FILE_MUTATION = gql`
   mutation UploadFile($input: CSVImportInput!) {
-    importCSV(input: $input) {
-      isOk
+    deviceInventory {
+      importCSV(input: $input) {
+        isOk
+      }
     }
   }
 `;
 const ZONES_QUERY = gql`
   query ZonesImport {
-    zones {
-      edges {
-        node {
-          id
-          name
+    deviceInventory {
+      zones {
+        edges {
+          node {
+            id
+            name
+          }
         }
       }
     }
@@ -113,7 +117,7 @@ const ImportCSVModal: VoidFunctionComponent<Props> = ({ onClose }) => {
     return null;
   }
 
-  const zones = data.zones.edges.map((e) => e.node);
+  const zones = data.deviceInventory.zones.edges.map((e) => e.node);
 
   return (
     <Modal isOpen onClose={onClose} size="5xl" closeOnOverlayClick={false}>

--- a/packages/frinx-inventory-client/src/components/search-by-label-input.tsx
+++ b/packages/frinx-inventory-client/src/components/search-by-label-input.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react';
 import { LabelsQuery } from '../__generated__/graphql';
 
 type Props = {
-  items: LabelsQuery['labels']['edges'];
+  items: LabelsQuery['deviceInventory']['labels']['edges'];
   selectedLabels: Item[];
   isCreationDisabled?: boolean;
   onSelectionChange: (labels?: Item[]) => void;

--- a/packages/frinx-inventory-client/src/helpers/convert.ts
+++ b/packages/frinx-inventory-client/src/helpers/convert.ts
@@ -1,25 +1,46 @@
-import { Workflow } from '@frinx/shared';
+import { omitNullValue } from '@frinx/shared';
 import { ModalWorkflowsQuery } from '../__generated__/graphql';
 
-export function convertGraphqlToClientWorkflow(workflowsData: ModalWorkflowsQuery): Workflow[] {
-  return workflowsData.workflows.edges.map((e) => {
-    const { node } = e;
-    const updateTime = node.updatedAt ? new Date(node.updatedAt).getMilliseconds() : 0;
-    return {
-      correlationId: '',
-      description: node.description ?? undefined,
-      hasSchedule: node.hasSchedule ?? false,
-      name: node.name,
-      version: node.version ?? 1,
-      outputParameters: node.outputParameters ?? {},
-      restartable: node.restartable ?? false,
-      ownerEmail: node.ownerEmail ?? '',
-      schemaVersion: 2,
-      updateTime,
-      timeoutPolicy: node.timeoutPolicy ?? '',
-      timeoutSeconds: node.timeoutSeconds,
-      variables: node.variables ?? {},
-      tasks: [],
-    };
-  });
+export type ModalWorkflow = {
+  correlationId: string;
+  description: string | undefined;
+  name: string;
+  version: number;
+  inputParameters: (string | null)[];
+  outputParameters: unknown;
+  restartable: boolean;
+  ownerEmail: string;
+  schemaVersion: number;
+  timeoutPolicy: string;
+  timeoutSeconds: unknown;
+  variables: unknown;
+  tasks: never[];
+};
+
+export function convertGraphqlToClientWorkflow(workflowsData: ModalWorkflowsQuery): ModalWorkflow[] {
+  if (workflowsData.conductor.getAll == null) {
+    return [];
+  }
+  return workflowsData.conductor.getAll
+    .map((workflow) => {
+      if (workflow == null) {
+        return null;
+      }
+      return {
+        correlationId: '',
+        description: workflow.description ?? undefined,
+        name: workflow.name,
+        version: workflow.version ?? 1,
+        inputParameters: workflow.inputParameters ?? [],
+        outputParameters: workflow.outputParameters ?? {},
+        restartable: workflow.restartable ?? false,
+        ownerEmail: workflow.ownerEmail ?? '',
+        schemaVersion: 2,
+        timeoutPolicy: workflow.timeoutPolicy ?? '',
+        timeoutSeconds: workflow.timeoutSeconds,
+        variables: workflow.variables ?? {},
+        tasks: [],
+      };
+    })
+    .filter(omitNullValue);
 }

--- a/packages/frinx-inventory-client/src/pages/create-blueprint/create-blueprint-page.tsx
+++ b/packages/frinx-inventory-client/src/pages/create-blueprint/create-blueprint-page.tsx
@@ -6,11 +6,13 @@ import CreateBlueprintForm from './create-blueprint-form';
 
 const ADD_BLUEPRINT_MUTATION = gql`
   mutation AddBlueprint($input: AddBlueprintInput!) {
-    addBlueprint(input: $input) {
-      blueprint {
-        id
-        createdAt
-        name
+    deviceInventory {
+      addBlueprint(input: $input) {
+        blueprint {
+          id
+          createdAt
+          name
+        }
       }
     }
   }

--- a/packages/frinx-inventory-client/src/pages/create-device/create-device-form.tsx
+++ b/packages/frinx-inventory-client/src/pages/create-device/create-device-form.tsx
@@ -31,9 +31,9 @@ import { ServiceState, serviceStateOptions, DeviceSizeEnum, deviceSizeOptions } 
 
 type Props = {
   isSubmitting: boolean;
-  zones: ZonesQuery['zones']['edges'];
-  labels: LabelsQuery['labels']['edges'];
-  blueprints: DeviceBlueprintsQuery['blueprints']['edges'];
+  zones: ZonesQuery['deviceInventory']['zones']['edges'];
+  labels: LabelsQuery['deviceInventory']['labels']['edges'];
+  blueprints: DeviceBlueprintsQuery['deviceInventory']['blueprints']['edges'];
   onFormSubmit: (device: FormValues) => void;
   onLabelCreate: (labelName: string) => Promise<Label | null>;
   deviceNameError: string | null;
@@ -221,7 +221,7 @@ const CreateDeviceForm: VoidFunctionComponent<Props> = ({
           />
         </FormControl>
 
-        <FormControl id="deviceSize" my={6} isInvalid={errors.deviceSize !== undefined}>
+        <FormControl id="deviceSize" isInvalid={errors.deviceSize !== undefined}>
           <FormLabel>Device size</FormLabel>
           <Select
             data-cy="add-device-size"

--- a/packages/frinx-inventory-client/src/pages/create-device/create-device-page.tsx
+++ b/packages/frinx-inventory-client/src/pages/create-device/create-device-page.tsx
@@ -21,14 +21,16 @@ import CreateDeviceForm from './create-device-form';
 
 const ADD_DEVICE_MUTATION = gql`
   mutation AddDevice($input: AddDeviceInput!) {
-    addDevice(input: $input) {
-      device {
-        id
-        name
-        isInstalled
-        zone {
+    deviceInventory {
+      addDevice(input: $input) {
+        device {
           id
           name
+          isInstalled
+          zone {
+            id
+            name
+          }
         }
       }
     }
@@ -36,11 +38,13 @@ const ADD_DEVICE_MUTATION = gql`
 `;
 const ZONES_QUERY = gql`
   query Zones {
-    zones {
-      edges {
-        node {
-          id
-          name
+    deviceInventory {
+      zones {
+        edges {
+          node {
+            id
+            name
+          }
         }
       }
     }
@@ -48,12 +52,14 @@ const ZONES_QUERY = gql`
 `;
 const BLUEPRINTS_QUERY = gql`
   query DeviceBlueprints {
-    blueprints {
-      edges {
-        node {
-          id
-          name
-          template
+    deviceInventory {
+      blueprints {
+        edges {
+          node {
+            id
+            name
+            template
+          }
         }
       }
     }
@@ -62,12 +68,14 @@ const BLUEPRINTS_QUERY = gql`
 
 const CREATE_LABEL = gql`
   mutation CreateLabel($input: CreateLabelInput!) {
-    newLabel: createLabel(input: $input) {
-      label {
-        id
-        name
-        createdAt
-        updatedAt
+    deviceInventory {
+      newLabel: createLabel(input: $input) {
+        label {
+          id
+          name
+          createdAt
+          updatedAt
+        }
       }
     }
   }
@@ -75,11 +83,13 @@ const CREATE_LABEL = gql`
 
 const LABELS_QUERY = gql`
   query Labels {
-    labels {
-      edges {
-        node {
-          id
-          name
+    deviceInventory {
+      labels {
+        edges {
+          node {
+            id
+            name
+          }
         }
       }
     }
@@ -129,7 +139,7 @@ const CreateDevicePage: FC<Props> = ({ onAddDeviceSuccess }) => {
 
   const handleOnCreateLabel = async (labelName: string): Promise<Label | null> => {
     const result = await createLabel({ input: { name: labelName } });
-    return result.data?.newLabel.label ?? null;
+    return result.data?.deviceInventory.newLabel.label ?? null;
   };
 
   const handleSubmit = (values: FormValues) => {
@@ -145,7 +155,7 @@ const CreateDevicePage: FC<Props> = ({ onAddDeviceSuccess }) => {
           error?.message ===
           '[GraphQL] There is a unique constraint violation, a new device cannot be added with this name.'
         ) {
-          setDeviceNameError('Device with this name alredy exists. Please select different name.');
+          setDeviceNameError('Device with this name alredy exists. Please enter a different name.');
         }
         if (error != null) {
           throw new Error('Problem with device addition');
@@ -164,10 +174,10 @@ const CreateDevicePage: FC<Props> = ({ onAddDeviceSuccess }) => {
     return <Progress size="xs" isIndeterminate mt={-10} />;
   }
 
-  const labels = labelsData?.labels.edges ?? [];
+  const labels = labelsData?.deviceInventory.labels.edges ?? [];
 
-  const zones = zonesData?.zones.edges ?? [];
-  const blueprints = blueprintsData?.blueprints.edges ?? [];
+  const zones = zonesData?.deviceInventory.zones.edges ?? [];
+  const blueprints = blueprintsData?.deviceInventory.blueprints.edges ?? [];
 
   if (isFetchingZones && isFetchingBlueprints) {
     return null;

--- a/packages/frinx-inventory-client/src/pages/device-blueprints/device-blueprints.tsx
+++ b/packages/frinx-inventory-client/src/pages/device-blueprints/device-blueprints.tsx
@@ -32,12 +32,14 @@ import {
 
 const BLUEPRINTS_QUERY = gql`
   query Blueprints {
-    blueprints {
-      edges {
-        node {
-          id
-          createdAt
-          name
+    deviceInventory {
+      blueprints {
+        edges {
+          node {
+            id
+            createdAt
+            name
+          }
         }
       }
     }
@@ -45,9 +47,11 @@ const BLUEPRINTS_QUERY = gql`
 `;
 const DELETE_BLUEPRINT_MUTATION = gql`
   mutation deleteBlueprint($id: String!) {
-    deleteBlueprint(id: $id) {
-      blueprint {
-        id
+    deviceInventory {
+      deleteBlueprint(id: $id) {
+        blueprint {
+          id
+        }
       }
     }
   }
@@ -69,7 +73,7 @@ const DeviceBlueprints: VoidFunctionComponent = () => {
   if (error) {
     return <div>{error.message}</div>;
   }
-  const { blueprints } = data;
+  const { blueprints } = data.deviceInventory;
 
   const handleDeleteBtnClick = (id: string) => {
     deleteBlueprint({
@@ -126,7 +130,6 @@ const DeviceBlueprints: VoidFunctionComponent = () => {
                       data-cy={`device-blueprint-edit-${blueprint.name}`}
                       aria-label="edit"
                       size="sm"
-                      variant="unstyled"
                       icon={<Icon size={30} as={FeatherIcon} icon="edit" />}
                       as={Link}
                       to={`${blueprint.id}/edit`}

--- a/packages/frinx-inventory-client/src/pages/device-config/device-config-page.tsx
+++ b/packages/frinx-inventory-client/src/pages/device-config/device-config-page.tsx
@@ -32,10 +32,12 @@ import DiffOutputModal from './diff-output-modal';
 
 const DEVICE_NAME_QUERY = gql`
   query deviceName($deviceId: ID!) {
-    node(id: $deviceId) {
-      ... on Device {
-        id
-        name
+    deviceInventory {
+      node(id: $deviceId) {
+        ... on Device {
+          id
+          name
+        }
       }
     }
   }
@@ -43,12 +45,14 @@ const DEVICE_NAME_QUERY = gql`
 
 const DATA_STORE_QUERY = gql`
   query dataStore($deviceId: String!, $transactionId: String!) {
-    dataStore(deviceId: $deviceId, transactionId: $transactionId) {
-      config
-      operational
-      snapshots {
-        name
-        createdAt
+    deviceInventory {
+      dataStore(deviceId: $deviceId, transactionId: $transactionId) {
+        config
+        operational
+        snapshots {
+          name
+          createdAt
+        }
       }
     }
   }
@@ -56,10 +60,12 @@ const DATA_STORE_QUERY = gql`
 
 const UPDATE_DATA_STORE_MUTATION = gql`
   mutation updateDataStore($deviceId: String!, $transactionId: String!, $input: UpdateDataStoreInput!) {
-    updateDataStore(deviceId: $deviceId, transactionId: $transactionId, input: $input) {
-      dataStore {
-        config
-        operational
+    deviceInventory {
+      updateDataStore(deviceId: $deviceId, transactionId: $transactionId, input: $input) {
+        dataStore {
+          config
+          operational
+        }
       }
     }
   }
@@ -67,10 +73,12 @@ const UPDATE_DATA_STORE_MUTATION = gql`
 
 const COMMIT_DATA_STORE_MUTATION = gql`
   mutation commitDataStoreConfig($transactionId: String!, $input: CommitConfigInput!) {
-    commitConfig(transactionId: $transactionId, input: $input) {
-      output {
-        configuration
-        message
+    deviceInventory {
+      commitConfig(transactionId: $transactionId, input: $input) {
+        output {
+          configuration
+          message
+        }
       }
     }
   }
@@ -78,10 +86,12 @@ const COMMIT_DATA_STORE_MUTATION = gql`
 
 const RESET_CONFIG_MUTATION = gql`
   mutation resetConfig($deviceId: String!, $transactionId: String!) {
-    resetConfig(deviceId: $deviceId, transactionId: $transactionId) {
-      dataStore {
-        config
-        operational
+    deviceInventory {
+      resetConfig(deviceId: $deviceId, transactionId: $transactionId) {
+        dataStore {
+          config
+          operational
+        }
       }
     }
   }
@@ -89,9 +99,11 @@ const RESET_CONFIG_MUTATION = gql`
 
 const ADD_SNAPSHOT_MUTATION = gql`
   mutation addSnapshot($transactionId: String!, $input: AddSnapshotInput!) {
-    addSnapshot(transactionId: $transactionId, input: $input) {
-      snapshot {
-        name
+    deviceInventory {
+      addSnapshot(transactionId: $transactionId, input: $input) {
+        snapshot {
+          name
+        }
       }
     }
   }
@@ -99,18 +111,22 @@ const ADD_SNAPSHOT_MUTATION = gql`
 
 const APPLY_SNAPSHOT_MUTATION = gql`
   mutation applySnapshot($transactionId: String!, $input: ApplySnapshotInput!) {
-    applySnapshot(transactionId: $transactionId, input: $input) {
-      isOk
-      output
+    deviceInventory {
+      applySnapshot(transactionId: $transactionId, input: $input) {
+        isOk
+        output
+      }
     }
   }
 `;
 
 const SYNC_FROM_NETWORK_MUTATION = gql`
   mutation syncFromNetwork($deviceId: String!, $transactionId: String!) {
-    syncFromNetwork(deviceId: $deviceId, transactionId: $transactionId) {
-      dataStore {
-        operational
+    deviceInventory {
+      syncFromNetwork(deviceId: $deviceId, transactionId: $transactionId) {
+        dataStore {
+          operational
+        }
       }
     }
   }
@@ -118,9 +134,11 @@ const SYNC_FROM_NETWORK_MUTATION = gql`
 
 const DELETE_SNAPSHOT_MUTATION = gql`
   mutation deleteSnapshot($input: DeleteSnapshotInput!) {
-    deleteSnapshot(input: $input) {
-      snapshot {
-        name
+    deviceInventory {
+      deleteSnapshot(input: $input) {
+        snapshot {
+          name
+        }
       }
     }
   }
@@ -186,13 +204,13 @@ const DeviceConfig: VoidFunctionComponent = () => {
   }, [error]);
 
   useEffect(() => {
-    if (data != null && data.dataStore != null) {
-      setConfig(JSON.stringify(JSON.parse(data.dataStore.config ?? ''), null, 2));
+    if (data != null && data.deviceInventory.dataStore != null) {
+      setConfig(JSON.stringify(JSON.parse(data.deviceInventory.dataStore.config ?? ''), null, 2));
     }
   }, [data]);
 
   useEffect(() => {
-    setCommitConfigData(commitData?.commitConfig.output.configuration ?? null);
+    setCommitConfigData(commitData?.deviceInventory.commitConfig.output.configuration ?? null);
   }, [commitData]);
 
   if (transactionId == null) {
@@ -378,7 +396,7 @@ const DeviceConfig: VoidFunctionComponent = () => {
       });
     }
 
-    if (responseData?.deleteSnapshot != null) {
+    if (responseData?.deviceInventory.deleteSnapshot != null) {
       addToastNotification({
         type: 'success',
         title: 'Success',
@@ -401,11 +419,11 @@ const DeviceConfig: VoidFunctionComponent = () => {
     return null;
   }
 
-  if (deviceData.node?.__typename !== 'Device') {
+  if (deviceData.deviceInventory.node?.__typename !== 'Device') {
     return null;
   }
 
-  const { name } = deviceData.node;
+  const { name } = deviceData.deviceInventory.node;
 
   if (hasTransactionError) {
     return (
@@ -446,7 +464,7 @@ const DeviceConfig: VoidFunctionComponent = () => {
     return <div>{error.message}</div>;
   }
 
-  const snapshots = data?.dataStore?.snapshots ?? [];
+  const snapshots = data?.deviceInventory.dataStore?.snapshots ?? [];
 
   return (
     <>
@@ -488,7 +506,7 @@ const DeviceConfig: VoidFunctionComponent = () => {
         <Box background="white" padding={4}>
           <DeviceConfigEditors
             config={config ?? ''}
-            operational={JSON.stringify(JSON.parse(data?.dataStore?.operational ?? ''), null, 2)}
+            operational={JSON.stringify(JSON.parse(data?.deviceInventory.dataStore?.operational ?? ''), null, 2)}
             onConfigChange={(cfg) => {
               setConfig(cfg);
             }}

--- a/packages/frinx-inventory-client/src/pages/device-config/device-config.helpers.ts
+++ b/packages/frinx-inventory-client/src/pages/device-config/device-config.helpers.ts
@@ -10,15 +10,19 @@ import {
 
 const CREATE_TRANSACTION_MUTATION = gql`
   mutation createTransaction($deviceId: String!) {
-    createTransaction(deviceId: $deviceId) {
-      transactionId
+    deviceInventory {
+      createTransaction(deviceId: $deviceId) {
+        transactionId
+      }
     }
   }
 `;
 const CLOSE_TRANSACTION_MUTATION = gql`
   mutation closeTransaction($deviceId: String!, $transactionId: String!) {
-    closeTransaction(deviceId: $deviceId, transactionId: $transactionId) {
-      isOk
+    deviceInventory {
+      closeTransaction(deviceId: $deviceId, transactionId: $transactionId) {
+        isOk
+      }
     }
   }
 `;
@@ -97,9 +101,9 @@ export const useTransactionId = (deviceId: string): UseTransactionId => {
           throw new Error(error.toString());
         }
 
-        if (data?.createTransaction.transactionId != null) {
-          setTransactionIdData({ deviceId, transactionId: data.createTransaction.transactionId });
-          setTranscationData(deviceId, data.createTransaction.transactionId);
+        if (data?.deviceInventory.createTransaction.transactionId != null) {
+          setTransactionIdData({ deviceId, transactionId: data.deviceInventory.createTransaction.transactionId });
+          setTranscationData(deviceId, data.deviceInventory.createTransaction.transactionId);
         }
       });
     }

--- a/packages/frinx-inventory-client/src/pages/device-config/diff-output-modal.tsx
+++ b/packages/frinx-inventory-client/src/pages/device-config/diff-output-modal.tsx
@@ -19,20 +19,22 @@ import { CalculatedDiffQuery, CalculatedDiffQueryVariables, CalculatedDiffResult
 
 const CALCULATED_DIFF_QUERY = gql`
   query calculatedDiff($deviceId: String!, $transactionId: String!) {
-    calculatedDiff(deviceId: $deviceId, transactionId: $transactionId) {
-      result {
-        createdData {
-          path
-          data
-        }
-        deletedData {
-          path
-          data
-        }
-        updatedData {
-          path
-          actualData
-          intendedData
+    deviceInventory {
+      calculatedDiff(deviceId: $deviceId, transactionId: $transactionId) {
+        result {
+          createdData {
+            path
+            data
+          }
+          deletedData {
+            path
+            data
+          }
+          updatedData {
+            path
+            actualData
+            intendedData
+          }
         }
       }
     }
@@ -90,11 +92,11 @@ const DiffOutputModal: VoidFunctionComponent<Props> = ({ onClose, deviceId, tran
     return null;
   }
 
-  if (data?.calculatedDiff == null) {
+  if (data?.deviceInventory.calculatedDiff == null) {
     return null;
   }
 
-  const { result } = data.calculatedDiff;
+  const { result } = data.deviceInventory.calculatedDiff;
   const { updatedData, ...rest } = result;
 
   return (

--- a/packages/frinx-inventory-client/src/pages/device-list/device-filters.tsx
+++ b/packages/frinx-inventory-client/src/pages/device-list/device-filters.tsx
@@ -5,7 +5,7 @@ import SearchByLabelInput from '../../components/search-by-label-input';
 import { LabelsQuery } from '../../__generated__/graphql';
 
 type Props = {
-  labels: LabelsQuery['labels']['edges'];
+  labels: LabelsQuery['deviceInventory']['labels']['edges'];
   selectedLabels: Item[];
   isCreationDisabled?: boolean;
   onSelectionChange: (labels?: Item[]) => void;

--- a/packages/frinx-inventory-client/src/pages/device-list/device-table.tsx
+++ b/packages/frinx-inventory-client/src/pages/device-list/device-table.tsx
@@ -31,7 +31,7 @@ type OrderBy = {
 
 type Props = {
   orderBy: OrderBy;
-  devices: DevicesQuery['devices']['edges'];
+  devices: DevicesQuery['deviceInventory']['devices']['edges'];
   selectedDevices: Set<string>;
   areSelectedAll: boolean;
   installLoadingMap: Record<string, boolean>;

--- a/packages/frinx-inventory-client/src/pages/device-list/workflow-list-modal.tsx
+++ b/packages/frinx-inventory-client/src/pages/device-list/workflow-list-modal.tsx
@@ -11,46 +11,29 @@ import {
   ModalOverlay,
   Text,
 } from '@chakra-ui/react';
-import { jsonParse, Workflow } from '@frinx/shared';
+import { jsonParse } from '@frinx/shared';
 import React, { VoidFunctionComponent } from 'react';
 import { gql, useQuery } from 'urql';
-import { convertGraphqlToClientWorkflow } from '../../helpers/convert';
+import { convertGraphqlToClientWorkflow, ModalWorkflow } from '../../helpers/convert';
 import { ModalWorkflowsQuery } from '../../__generated__/graphql';
 
 const MODAL_WORKFLOWS_QUERY = gql`
   query ModalWorkflows {
-    workflows {
-      edges {
-        node {
-          id
-          name
-          description
-          version
-          createdAt
-          updatedAt
-          createdBy
-          updatedBy
-          tasks
-          hasSchedule
-          inputParameters
-          outputParameters {
-            key
-            value
-          }
-          restartable
-          timeoutSeconds
-          timeoutPolicy
-          ownerEmail
-          schemaVersion
-          variables
-        }
-      }
-      totalCount
-      pageInfo {
-        startCursor
-        endCursor
-        hasNextPage
-        hasPreviousPage
+    conductor {
+      getAll {
+        name
+        description
+        version
+        createdBy
+        updatedBy
+        inputParameters
+        outputParameters
+        restartable
+        timeoutSeconds
+        timeoutPolicy
+        ownerEmail
+        schemaVersion
+        variables
       }
     }
   }
@@ -58,7 +41,7 @@ const MODAL_WORKFLOWS_QUERY = gql`
 
 type Props = {
   onClose: () => void;
-  onWorkflowSelect: (workflow: Workflow) => void;
+  onWorkflowSelect: (workflow: ModalWorkflow) => void;
 };
 
 const WorkflowListModal: VoidFunctionComponent<Props> = ({ onClose, onWorkflowSelect }) => {
@@ -70,7 +53,7 @@ const WorkflowListModal: VoidFunctionComponent<Props> = ({ onClose, onWorkflowSe
     return null;
   }
 
-  const workflows: Workflow[] = convertGraphqlToClientWorkflow(workflowsData);
+  const workflows = convertGraphqlToClientWorkflow(workflowsData);
 
   const labeledWorkflows = workflows.filter((wf) => {
     const labels = jsonParse<{ labels: string[] }>(wf.description)?.labels ?? [];

--- a/packages/frinx-inventory-client/src/pages/edit-blueprint/edit-blueprint-page.tsx
+++ b/packages/frinx-inventory-client/src/pages/edit-blueprint/edit-blueprint-page.tsx
@@ -8,11 +8,13 @@ import EditBlueprintForm, { FormValues } from './edit-blueprint-form';
 
 const BLUEPRINT_QUERY = gql`
   query Blueprint($id: ID!) {
-    blueprint: node(id: $id) {
-      id
-      ... on Blueprint {
-        name
-        template
+    deviceInventory {
+      blueprint: node(id: $id) {
+        id
+        ... on Blueprint {
+          name
+          template
+        }
       }
     }
   }
@@ -20,11 +22,13 @@ const BLUEPRINT_QUERY = gql`
 
 const UPDATE_BLUEPRINT_MUTATION = gql`
   mutation UpdateBlueprint($id: String!, $input: UpdateBlueprintInput!) {
-    updateBlueprint(id: $id, input: $input) {
-      blueprint {
-        id
-        name
-        template
+    deviceInventory {
+      updateBlueprint(id: $id, input: $input) {
+        blueprint {
+          id
+          name
+          template
+        }
       }
     }
   }
@@ -41,7 +45,7 @@ const EditBlueprintPage: FC<Props> = ({ onSuccess, onCancel }) => {
     UpdateBlueprintMutation,
     UpdateBlueprintMutationVariables
   >(UPDATE_BLUEPRINT_MUTATION);
-  const [{ data: blueprint, fetching: isLoadingBlueprint, error }] = useQuery({
+  const [{ data: blueprintData, fetching: isLoadingBlueprint, error }] = useQuery({
     query: BLUEPRINT_QUERY,
     variables: { id: blueprintId },
   });
@@ -72,21 +76,26 @@ const EditBlueprintPage: FC<Props> = ({ onSuccess, onCancel }) => {
     });
   };
 
-  if (isLoadingBlueprint && blueprint == null) {
+  if (isLoadingBlueprint && blueprintData == null) {
     return <Progress isIndeterminate mt={-10} size="xs" />;
   }
 
   if (!isLoadingBlueprint && error != null) {
     onCancel();
   }
+  const { blueprint } = blueprintData.deviceInventory;
+
+  if (blueprint == null) {
+    return null;
+  }
 
   return (
     <Container maxWidth={1280}>
       <Heading size="3xl" as="h2" mb={2}>
-        Edit {blueprint?.blueprint?.name}
+        Edit {blueprint.name}
       </Heading>
       <Box background="white" boxShadow="base" px={4} py={2}>
-        <EditBlueprintForm onSubmit={handleSubmit} onCancel={onCancel} initialValues={blueprint?.blueprint} />
+        <EditBlueprintForm onSubmit={handleSubmit} onCancel={onCancel} initialValues={blueprint} />
       </Box>
     </Container>
   );

--- a/packages/frinx-inventory-client/src/pages/edit-device/edit-device-form.tsx
+++ b/packages/frinx-inventory-client/src/pages/edit-device/edit-device-form.tsx
@@ -1,7 +1,6 @@
 import { useFormik } from 'formik';
 import React, { FC, useMemo } from 'react';
 import * as yup from 'yup';
-
 import { Item } from 'chakra-ui-autocomplete';
 import {
   Button,
@@ -36,8 +35,8 @@ type FormLabel = { id: string; name: string };
 export type FormDevice = Device & { labels: FormLabel[] };
 
 type Props = {
-  labels: LabelsQuery['labels']['edges'];
-  zones: ZonesQuery['zones']['edges']; // eslint-disable-line react/no-unused-prop-types
+  labels: LabelsQuery['deviceInventory']['labels']['edges'];
+  zones: ZonesQuery['deviceInventory']['zones']['edges']; // eslint-disable-line react/no-unused-prop-types
   device: FormDevice;
   onUpdate: (values: FormValues) => void;
   onLabelCreate: (label: string) => Promise<Label | null>;

--- a/packages/frinx-inventory-client/src/pages/edit-device/edit-device-page.tsx
+++ b/packages/frinx-inventory-client/src/pages/edit-device/edit-device-page.tsx
@@ -23,25 +23,27 @@ import EditDeviceForm from './edit-device-form';
 
 const DEVICE_QUERY = gql`
   query Device($id: ID!) {
-    device: node(id: $id) {
-      id
-      ... on Device {
-        name
-        serviceState
-        model
-        vendor
-        address
-        deviceSize
-        mountParameters
-        zone {
-          id
+    deviceInventory {
+      device: node(id: $id) {
+        id
+        ... on Device {
           name
-        }
-        labels {
-          edges {
-            node {
-              id
-              name
+          serviceState
+          model
+          vendor
+          address
+          deviceSize
+          mountParameters
+          zone {
+            id
+            name
+          }
+          labels {
+            edges {
+              node {
+                id
+                name
+              }
             }
           }
         }
@@ -52,17 +54,19 @@ const DEVICE_QUERY = gql`
 
 const UPDATE_DEVICE_MUTATION = gql`
   mutation UpdateDevice($id: String!, $input: UpdateDeviceInput!) {
-    updateDevice(id: $id, input: $input) {
-      device {
-        id
-        name
-        model
-        vendor
-        address
-        isInstalled
-        zone {
+    deviceInventory {
+      updateDevice(id: $id, input: $input) {
+        device {
           id
           name
+          model
+          vendor
+          address
+          isInstalled
+          zone {
+            id
+            name
+          }
         }
       }
     }
@@ -71,11 +75,13 @@ const UPDATE_DEVICE_MUTATION = gql`
 
 const ZONES_QUERY = gql`
   query Zones {
-    zones {
-      edges {
-        node {
-          id
-          name
+    deviceInventory {
+      zones {
+        edges {
+          node {
+            id
+            name
+          }
         }
       }
     }
@@ -84,12 +90,14 @@ const ZONES_QUERY = gql`
 
 const CREATE_LABEL = gql`
   mutation CreateLabel($input: CreateLabelInput!) {
-    newLabel: createLabel(input: $input) {
-      label {
-        id
-        name
-        createdAt
-        updatedAt
+    deviceInventory {
+      newLabel: createLabel(input: $input) {
+        label {
+          id
+          name
+          createdAt
+          updatedAt
+        }
       }
     }
   }
@@ -97,11 +105,13 @@ const CREATE_LABEL = gql`
 
 const LABELS_QUERY = gql`
   query Labels {
-    labels {
-      edges {
-        node {
-          id
-          name
+    deviceInventory {
+      labels {
+        edges {
+          node {
+            id
+            name
+          }
         }
       }
     }
@@ -145,7 +155,7 @@ const EditDevicePage: FC<Props> = ({ onSuccess, onCancelButtonClick }) => {
       },
     });
 
-    return result.data?.newLabel?.label ?? null;
+    return result.data?.deviceInventory.newLabel?.label ?? null;
   };
 
   const handleOnUpdateDevice = (values: FormValues) => {
@@ -184,11 +194,11 @@ const EditDevicePage: FC<Props> = ({ onSuccess, onCancelButtonClick }) => {
     return <Progress size="xs" isIndeterminate mt={-10} />;
   }
 
-  if (deviceData == null || deviceData?.device == null) {
+  if (deviceData == null || deviceData?.deviceInventory.device == null) {
     return null;
   }
 
-  const { device } = deviceData;
+  const { device } = deviceData.deviceInventory;
 
   if (device.__typename !== 'Device') {
     return null;
@@ -215,8 +225,8 @@ const EditDevicePage: FC<Props> = ({ onSuccess, onCancelButtonClick }) => {
     deviceSize: device.deviceSize,
   };
 
-  const mappedLabels = labels?.labels.edges ?? [];
-  const mappedZones = zones?.zones.edges ?? [];
+  const mappedLabels = labels?.deviceInventory.labels.edges ?? [];
+  const mappedZones = zones?.deviceInventory.zones.edges ?? [];
 
   return (
     <Container maxWidth={1280}>

--- a/packages/frinx-inventory-client/src/pages/uniconfig-shell/uniconfig-shell.tsx
+++ b/packages/frinx-inventory-client/src/pages/uniconfig-shell/uniconfig-shell.tsx
@@ -11,12 +11,16 @@ import {
 
 const TERMINAL_SUBSCRIPTION = gql`
   subscription Terminal($sessionId: String!, $command: String, $trigger: Int) {
-    uniconfigShell(sessionId: $sessionId, input: $command, trigger: $trigger)
+    deviceInventory {
+      uniconfigShell(sessionId: $sessionId, input: $command, trigger: $trigger)
+    }
   }
 `;
 const TERMINAL_SESSION_ID_QUERY = gql`
   query SessionId {
-    uniconfigShellSession
+    deviceInventory {
+      uniconfigShellSession
+    }
   }
 `;
 
@@ -29,9 +33,9 @@ const UniconfigShell: VoidFunctionComponent = () => {
   });
   const [{ data: terminalData }] = useSubscription<TerminalSubscriptionVariables, TerminalSubscription>({
     query: TERMINAL_SUBSCRIPTION,
-    pause: sessionIdData?.uniconfigShellSession == null,
+    pause: sessionIdData?.deviceInventory.uniconfigShellSession == null,
     variables: {
-      sessionId: sessionIdData?.uniconfigShellSession,
+      sessionId: sessionIdData?.deviceInventory.uniconfigShellSession,
       command,
       trigger,
     },
@@ -40,8 +44,8 @@ const UniconfigShell: VoidFunctionComponent = () => {
   // a little hack to force re-render when we get the same character in sequence
   // React wouldn't re-render, because a === a, that's why we wrap it in object and send useless `trigger` (see `setCommand` callback fn)
   const commandObject = useMemo(
-    () => ({ command: terminalData?.uniconfigShell ?? '', trigger }),
-    [terminalData?.uniconfigShell, trigger],
+    () => ({ command: terminalData?.deviceInventory.uniconfigShell ?? '', trigger }),
+    [terminalData?.deviceInventory.uniconfigShell, trigger],
   );
 
   useTerm({

--- a/packages/shared/src/components/execute-workflow-modal/execute-workflow-modal.tsx
+++ b/packages/shared/src/components/execute-workflow-modal/execute-workflow-modal.tsx
@@ -20,7 +20,24 @@ import { useWorkflowInputsForm } from '../../hooks';
 import WorkflowInputsForm from '../workflow-inputs-form/workflow-inputs-form';
 
 type Props = {
-  workflow: Workflow | ClientWorkflow;
+  workflow:
+  | Workflow
+  | ClientWorkflow
+  | {
+    correlationId: string;
+    description: string | undefined;
+    name: string;
+    version: number;
+    inputParameters: (string | null)[];
+    outputParameters: unknown;
+    restartable: boolean;
+    ownerEmail: string;
+    schemaVersion: number;
+    timeoutPolicy: string;
+    timeoutSeconds: unknown;
+    variables: unknown;
+    tasks: never[];
+  };
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (inputParameters: Record<string, unknown>) => Promise<string | void | null> | null;

--- a/packages/shared/src/components/execute-workflow-modal/execute-workflow-modal.tsx
+++ b/packages/shared/src/components/execute-workflow-modal/execute-workflow-modal.tsx
@@ -21,23 +21,23 @@ import WorkflowInputsForm from '../workflow-inputs-form/workflow-inputs-form';
 
 type Props = {
   workflow:
-  | Workflow
-  | ClientWorkflow
-  | {
-    correlationId: string;
-    description: string | undefined;
-    name: string;
-    version: number;
-    inputParameters: (string | null)[];
-    outputParameters: unknown;
-    restartable: boolean;
-    ownerEmail: string;
-    schemaVersion: number;
-    timeoutPolicy: string;
-    timeoutSeconds: unknown;
-    variables: unknown;
-    tasks: never[];
-  };
+    | Workflow
+    | ClientWorkflow
+    | {
+        correlationId: string;
+        description: string | undefined;
+        name: string;
+        version: number;
+        inputParameters: (string | null)[];
+        outputParameters: unknown;
+        restartable: boolean;
+        ownerEmail: string;
+        schemaVersion: number;
+        timeoutPolicy: string;
+        timeoutSeconds: unknown;
+        variables: unknown;
+        tasks: never[];
+      };
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (inputParameters: Record<string, unknown>) => Promise<string | void | null> | null;

--- a/packages/shared/src/components/execute-workflow-modal/execute-workflow-modal.tsx
+++ b/packages/shared/src/components/execute-workflow-modal/execute-workflow-modal.tsx
@@ -19,25 +19,24 @@ import { jsonParse } from '../../helpers/workflow.helpers';
 import { useWorkflowInputsForm } from '../../hooks';
 import WorkflowInputsForm from '../workflow-inputs-form/workflow-inputs-form';
 
+type ModalWorkflow = {
+  correlationId: string;
+  description: string | undefined;
+  name: string;
+  version: number;
+  inputParameters: (string | null)[];
+  outputParameters: unknown;
+  restartable: boolean;
+  ownerEmail: string;
+  schemaVersion: number;
+  timeoutPolicy: string;
+  timeoutSeconds: unknown;
+  variables: unknown;
+  tasks: never[];
+};
+
 type Props = {
-  workflow:
-    | Workflow
-    | ClientWorkflow
-    | {
-        correlationId: string;
-        description: string | undefined;
-        name: string;
-        version: number;
-        inputParameters: (string | null)[];
-        outputParameters: unknown;
-        restartable: boolean;
-        ownerEmail: string;
-        schemaVersion: number;
-        timeoutPolicy: string;
-        timeoutSeconds: unknown;
-        variables: unknown;
-        tasks: never[];
-      };
+  workflow: Workflow | ClientWorkflow | ModalWorkflow;
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (inputParameters: Record<string, unknown>) => Promise<string | void | null> | null;

--- a/packages/shared/src/helpers/workflow.helpers.ts
+++ b/packages/shared/src/helpers/workflow.helpers.ts
@@ -9,26 +9,24 @@ export type InputParameter = Record<
   { value: string; description: string; type: string; options?: string[] | null }
 >;
 
+type ModalWorkflow = {
+  correlationId: string;
+  description: string | undefined;
+  name: string;
+  version: number;
+  inputParameters: (string | null)[];
+  outputParameters: unknown;
+  restartable: boolean;
+  ownerEmail: string;
+  schemaVersion: number;
+  timeoutPolicy: string;
+  timeoutSeconds: unknown;
+  variables: unknown;
+  tasks: never[];
+};
+
 export const getDynamicInputParametersFromWorkflow = (
-  workflow?:
-    | {
-        correlationId: string;
-        description: string | undefined;
-        name: string;
-        version: number;
-        inputParameters: (string | null)[];
-        outputParameters: unknown;
-        restartable: boolean;
-        ownerEmail: string;
-        schemaVersion: number;
-        timeoutPolicy: string;
-        timeoutSeconds: unknown;
-        variables: unknown;
-        tasks: never[];
-      }
-    | Workflow
-    | ClientWorkflow
-    | null,
+  workflow?: ModalWorkflow | Workflow | ClientWorkflow | null,
 ): string[] => {
   const REGEX = /workflow\.input\.([a-zA-Z0-9-_]+)/gim;
   const stringifiedWorkflow = JSON.stringify(workflow || {});
@@ -136,7 +134,7 @@ export function createEmptyWorkflow(): Pick<
   | 'timeoutPolicy'
   | 'timeoutSeconds'
   | 'outputParameters'
-  // | 'variables'
+// | 'variables'
 > {
   return {
     id: '',

--- a/packages/shared/src/helpers/workflow.helpers.ts
+++ b/packages/shared/src/helpers/workflow.helpers.ts
@@ -129,12 +129,10 @@ export function createEmptyWorkflow(): Pick<
   | 'tasks'
   | 'inputParameters'
   | 'labels'
-  // | 'ownerEmail'
   | 'restartable'
   | 'timeoutPolicy'
   | 'timeoutSeconds'
   | 'outputParameters'
-// | 'variables'
 > {
   return {
     id: '',

--- a/packages/shared/src/helpers/workflow.helpers.ts
+++ b/packages/shared/src/helpers/workflow.helpers.ts
@@ -12,20 +12,20 @@ export type InputParameter = Record<
 export const getDynamicInputParametersFromWorkflow = (
   workflow?:
     | {
-      correlationId: string;
-      description: string | undefined;
-      name: string;
-      version: number;
-      inputParameters: (string | null)[];
-      outputParameters: unknown;
-      restartable: boolean;
-      ownerEmail: string;
-      schemaVersion: number;
-      timeoutPolicy: string;
-      timeoutSeconds: unknown;
-      variables: unknown;
-      tasks: never[];
-    }
+        correlationId: string;
+        description: string | undefined;
+        name: string;
+        version: number;
+        inputParameters: (string | null)[];
+        outputParameters: unknown;
+        restartable: boolean;
+        ownerEmail: string;
+        schemaVersion: number;
+        timeoutPolicy: string;
+        timeoutSeconds: unknown;
+        variables: unknown;
+        tasks: never[];
+      }
     | Workflow
     | ClientWorkflow
     | null,
@@ -136,7 +136,7 @@ export function createEmptyWorkflow(): Pick<
   | 'timeoutPolicy'
   | 'timeoutSeconds'
   | 'outputParameters'
-// | 'variables'
+  // | 'variables'
 > {
   return {
     id: '',

--- a/packages/shared/src/helpers/workflow.helpers.ts
+++ b/packages/shared/src/helpers/workflow.helpers.ts
@@ -9,7 +9,27 @@ export type InputParameter = Record<
   { value: string; description: string; type: string; options?: string[] | null }
 >;
 
-export const getDynamicInputParametersFromWorkflow = (workflow?: Workflow | ClientWorkflow | null): string[] => {
+export const getDynamicInputParametersFromWorkflow = (
+  workflow?:
+    | {
+      correlationId: string;
+      description: string | undefined;
+      name: string;
+      version: number;
+      inputParameters: (string | null)[];
+      outputParameters: unknown;
+      restartable: boolean;
+      ownerEmail: string;
+      schemaVersion: number;
+      timeoutPolicy: string;
+      timeoutSeconds: unknown;
+      variables: unknown;
+      tasks: never[];
+    }
+    | Workflow
+    | ClientWorkflow
+    | null,
+): string[] => {
   const REGEX = /workflow\.input\.([a-zA-Z0-9-_]+)/gim;
   const stringifiedWorkflow = JSON.stringify(workflow || {});
   const match = stringifiedWorkflow.match(REGEX)?.map((path) => path.replace('workflow.input.', ''));
@@ -30,12 +50,13 @@ export const jsonParse = <T = { description: string }>(json?: string | null): T 
   }
 };
 
-export function parseInputParameters(inputParameters?: string[] | null): InputParameter | null {
+export function parseInputParameters(inputParameters?: (string | null)[] | null): InputParameter | null {
   if (inputParameters == null || inputParameters.length === 0) {
     return null;
   }
 
   const parsedInputParameters: InputParameter[] = inputParameters
+    .filter(omitNullValue)
     .map((v) => jsonParse<InputParameter>(v))
     .filter(omitNullValue);
 
@@ -115,7 +136,7 @@ export function createEmptyWorkflow(): Pick<
   | 'timeoutPolicy'
   | 'timeoutSeconds'
   | 'outputParameters'
-  // | 'variables'
+// | 'variables'
 > {
   return {
     id: '',

--- a/packages/shared/src/hooks/use-workflow-inputs-form.ts
+++ b/packages/shared/src/hooks/use-workflow-inputs-form.ts
@@ -8,7 +8,25 @@ import {
 } from '../helpers/workflow.helpers';
 
 type HookProps = {
-  workflow?: ClientWorkflow | Workflow | null;
+  workflow?:
+  | {
+    correlationId: string;
+    description: string | undefined;
+    name: string;
+    version: number;
+    inputParameters: (string | null)[];
+    outputParameters: unknown;
+    restartable: boolean;
+    ownerEmail: string;
+    schemaVersion: number;
+    timeoutPolicy: string;
+    timeoutSeconds: unknown;
+    variables: unknown;
+    tasks: never[];
+  }
+  | ClientWorkflow
+  | Workflow
+  | null;
   initialValues?: Record<string, string | number | boolean | string[]> | null;
   onSubmit: (values: Record<string, string | number | boolean | string[]>) => void;
 };
@@ -25,7 +43,7 @@ type HookReturn = {
 };
 
 const useWorkflowInputsForm = ({ initialValues, workflow, onSubmit }: HookProps): HookReturn => {
-  const parsedInputParameters = parseInputParameters(workflow?.inputParameters || []);
+  const parsedInputParameters = parseInputParameters(workflow?.inputParameters ?? []);
   const dynamicInputParameters = getDynamicInputParametersFromWorkflow(workflow);
   const parsedInitialValues = getInitialValuesFromParsedInputParameters(parsedInputParameters, dynamicInputParameters);
   const { values, handleSubmit, submitForm, isSubmitting, setSubmitting, setFieldValue } = useFormik<

--- a/packages/shared/src/hooks/use-workflow-inputs-form.ts
+++ b/packages/shared/src/hooks/use-workflow-inputs-form.ts
@@ -9,24 +9,24 @@ import {
 
 type HookProps = {
   workflow?:
-  | {
-    correlationId: string;
-    description: string | undefined;
-    name: string;
-    version: number;
-    inputParameters: (string | null)[];
-    outputParameters: unknown;
-    restartable: boolean;
-    ownerEmail: string;
-    schemaVersion: number;
-    timeoutPolicy: string;
-    timeoutSeconds: unknown;
-    variables: unknown;
-    tasks: never[];
-  }
-  | ClientWorkflow
-  | Workflow
-  | null;
+    | {
+        correlationId: string;
+        description: string | undefined;
+        name: string;
+        version: number;
+        inputParameters: (string | null)[];
+        outputParameters: unknown;
+        restartable: boolean;
+        ownerEmail: string;
+        schemaVersion: number;
+        timeoutPolicy: string;
+        timeoutSeconds: unknown;
+        variables: unknown;
+        tasks: never[];
+      }
+    | ClientWorkflow
+    | Workflow
+    | null;
   initialValues?: Record<string, string | number | boolean | string[]> | null;
   onSubmit: (values: Record<string, string | number | boolean | string[]>) => void;
 };

--- a/packages/shared/src/hooks/use-workflow-inputs-form.ts
+++ b/packages/shared/src/hooks/use-workflow-inputs-form.ts
@@ -7,26 +7,24 @@ import {
   getInitialValuesFromParsedInputParameters,
 } from '../helpers/workflow.helpers';
 
+type ModalWorkflow = {
+  correlationId: string;
+  description: string | undefined;
+  name: string;
+  version: number;
+  inputParameters: (string | null)[];
+  outputParameters: unknown;
+  restartable: boolean;
+  ownerEmail: string;
+  schemaVersion: number;
+  timeoutPolicy: string;
+  timeoutSeconds: unknown;
+  variables: unknown;
+  tasks: never[];
+};
+
 type HookProps = {
-  workflow?:
-    | {
-        correlationId: string;
-        description: string | undefined;
-        name: string;
-        version: number;
-        inputParameters: (string | null)[];
-        outputParameters: unknown;
-        restartable: boolean;
-        ownerEmail: string;
-        schemaVersion: number;
-        timeoutPolicy: string;
-        timeoutSeconds: unknown;
-        variables: unknown;
-        tasks: never[];
-      }
-    | ClientWorkflow
-    | Workflow
-    | null;
+  workflow?: ModalWorkflow | ClientWorkflow | Workflow | null;
   initialValues?: Record<string, string | number | boolean | string[]> | null;
   onSubmit: (values: Record<string, string | number | boolean | string[]>) => void;
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,4 +3,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   arrowParens: 'always',
+  semi: true,
 };


### PR DESCRIPTION
Moved all inventory server queries to the new graphql proxy server queries.

HOW TO TEST:
- make sure you have the new proxy server running (localhost:5555)
- have a running inventory server on `story-new-graphql-proxy` branch
- click around the inventory UI (just running type-check should be enough though)
