### PR TITLE
list input parameters in execute workflow modal fix

### DIFF
--- a/packages/shared/src/components/workflow-inputs-form/workflow-form-input.tsx
+++ b/packages/shared/src/components/workflow-inputs-form/workflow-form-input.tsx
@@ -17,6 +17,15 @@ import { InputParameter } from '../../helpers/workflow.helpers';
 import Editor from '../editor/editor';
 import SearchByTagInput from '../search-by-tag/search-by-tag-input';
 
+function getSelectedTags(list: string): string[] {
+  try {
+    const parsedList = JSON.parse(list);
+    return parsedList;
+  } catch {
+    return [];
+  }
+}
+
 type Props = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   values: Record<string, any>;
@@ -75,8 +84,8 @@ const WorkflowFormInput: VoidFunctionComponent<Props> = ({
           <SearchByTagInput
             isList
             tagText=""
-            selectedTags={values[inputParameterKey]}
-            onSelectionChange={(selectedTags) => onChange(inputParameterKey, selectedTags ?? [])}
+            selectedTags={getSelectedTags(values[inputParameterKey])}
+            onSelectionChange={(selectedTags) => onChange(inputParameterKey, JSON.stringify(selectedTags))}
           />
         </FormControl>
       )}


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-666` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
HOW TO TEST:

1. create workflow
2. open action > workflow editor and change workflow inputParameters:
```"inputParameters": [
    "{\"test_list\": {\"value\": \"\", \"description\": \"Test list\", \"type\": \"list\", \"options\": null}}"
  ],
```
3. try to execute workflow

modal should work