### PR TITLE
fix status label when connections not present

### DIFF
--- a/packages/shared/src/helpers/device.helpers.ts
+++ b/packages/shared/src/helpers/device.helpers.ts
@@ -24,7 +24,7 @@ export const getDeviceUsage = (
     return DeviceUsageWatermark.IN_SERVICE;
   }
 
-  if ((cpuLoad == null || memoryLoad == null) && !deviceConnection && deviceInstallStatus) {
+  if ((cpuLoad == null || memoryLoad == null) && deviceConnection === 'offline' && deviceInstallStatus) {
     return DeviceUsageWatermark.OFFLINE;
   }
 
@@ -52,11 +52,7 @@ export const getDeviceUsage = (
     return DeviceUsageWatermark.IN_SERVICE;
   }
 
-  if (
-    (isLowUsage(cpuLoad) || isLowUsage(memoryLoad)) &&
-    (deviceConnection === 'offline' || !deviceConnection) &&
-    deviceInstallStatus
-  ) {
+  if ((isLowUsage(cpuLoad) || isLowUsage(memoryLoad)) && deviceConnection === 'offline' && deviceInstallStatus) {
     return DeviceUsageWatermark.OFFLINE;
   }
 


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-680` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
devices status labels set to UNKNOWN when device connection not present yet. In some cases it was set to OFFLINE instead.

implemented/tested against:

ssh frinx@10.19.0.25
password: frinx

kubectl port-forward services/frinx-frontend 5555:5555 -n fm-staging --address 0.0.0.0

INVENTORY_API_URL="http://10.19.0.25:5555/graphql"
INVENTORY_WS_PATH="/graphql"
INVENTORY_WS_SCHEMA="ws://"
INVENTORY_WS_URL="wss://10.19.0.25:5555/graphql"
DEV_INVENTORY_WS_URL="ws://10.19.0.25:5555/graphql"