### PR TITLE
FD-712 lsp count glitch fix

### DIFF
--- a/packages/frinx-device-topology/src/state.reducer.ts
+++ b/packages/frinx-device-topology/src/state.reducer.ts
@@ -583,6 +583,7 @@ export function stateReducer(state: State, action: StateAction): State {
       case 'SET_SELECTED_MPLS_NODE': {
         if (acc.selectedNode?.id !== action.node?.id) {
           acc.selectedEdge = null;
+          acc.lspCounts = [];
         }
         acc.selectedNode = action.node;
         const connectedEdges = acc.synceEdges.filter(


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-712` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
HOW TO TEST:

try to choose C! and C2 mpls nodes, there should be no blinking of lsp counts visible
