### PR TITLE
FD-713 filter out devices without geolocation

### DIFF
--- a/packages/frinx-device-topology/src/__generated__/graphql.ts
+++ b/packages/frinx-device-topology/src/__generated__/graphql.ts
@@ -943,6 +943,10 @@ export type FilterLabelsInput = {
   name: Scalars['String']['input'];
 };
 
+export type FilterLocationsInput = {
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type FilterNeighborInput = {
   deviceName: Scalars['String']['input'];
   topologyType: TopologyType;
@@ -1117,6 +1121,11 @@ export type LocationEdge = {
   __typename?: 'LocationEdge';
   cursor: Scalars['String']['output'];
   node: Location;
+};
+
+export type LocationOrderByInput = {
+  direction: SortDirection;
+  sortKey: SortLocationBy;
 };
 
 export type LspPath = {
@@ -1624,6 +1633,9 @@ export type SortExecutedWorkflowsBy =
 export type SortExecutedWorkflowsDirection =
   | 'asc'
   | 'desc';
+
+export type SortLocationBy =
+  | 'name';
 
 export type SortResourcePoolsInput = {
   direction: OrderDirection;
@@ -3568,8 +3580,10 @@ export type DeviceInventoryQueryLabelsArgs = {
 export type DeviceInventoryQueryLocationsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<FilterLocationsInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<LocationOrderByInput>;
 };
 
 

--- a/packages/frinx-device-topology/src/state.reducer.ts
+++ b/packages/frinx-device-topology/src/state.reducer.ts
@@ -549,7 +549,7 @@ export function stateReducer(state: State, action: StateAction): State {
       }
 
       case 'SET_DEVICES_METADATA': {
-        acc.devicesMetadata = action.payload;
+        acc.devicesMetadata = action.payload.filter((d) => d.geolocation.latitude && d.geolocation.longitude);
         return acc;
       }
       case 'SET_SELECTED_PTP_NODE': {


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issue?             | `FD-666` <!-- ticket number from JIRA -->
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
HOW TO TEST:
you can set deviceMetadata response to send back something like this:
```
   nodes: [
            {
              id: 'TWFwTm9kZTpEZXZpY2VNZXRhZGF0YS8x',
              deviceName: 'cli@172.20.20.1',
              locationName: null,
              geolocation: null,
              __typename: 'GeoMapDevice',
            },
            {
              id: 'TWFwTm9kZTpEZXZpY2VNZXRhZGF0YS8y',
              deviceName: 'DC1_PE1@cli',
              locationName: 'Rusovce Airport',
              geolocation: {
                latitude: 48.05254,
                longitude: 17.13692,
                __typename: 'Geolocation',
              },
              __typename: 'GeoMapDevice',
            },
          ],
```

this branch should work fine (device without geolocation is filtered out), while in main it will crash
 